### PR TITLE
Add trickplay thumbnail preview to PlayerScrubber

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: 0.3.4(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@tanstack/react-devtools':
         specifier: ^0.9.4
-        version: 0.9.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
+        version: 0.9.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)
       '@tanstack/react-query-devtools':
         specifier: ^5.91.3
         version: 5.91.3(@tanstack/react-query@5.90.20(react@19.2.4))(react@19.2.4)
@@ -148,7 +148,7 @@ importers:
         version: 3.8.1
       shadcn:
         specifier: ^3.8.1
-        version: 3.8.1(@types/node@25.1.0)(hono@4.11.3)(typescript@5.9.3)
+        version: 3.8.1(@types/node@25.1.0)(hono@4.11.7)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -2323,8 +2323,8 @@ packages:
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
-  hono@4.11.3:
-    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+  hono@4.11.7:
+    resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -3162,12 +3162,6 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  seroval-plugins@1.3.3:
-    resolution: {integrity: sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: '>=1.4.1'
-
   seroval-plugins@1.5.0:
     resolution: {integrity: sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==}
     engines: {node: '>=10'}
@@ -3230,8 +3224,8 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  solid-js@1.9.10:
-    resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
+  solid-js@1.9.11:
+    resolution: {integrity: sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -4190,9 +4184,9 @@ snapshots:
 
   '@fontsource-variable/dm-sans@5.2.8': {}
 
-  '@hono/node-server@1.19.9(hono@4.11.3)':
+  '@hono/node-server@1.19.9(hono@4.11.7)':
     dependencies:
-      hono: 4.11.3
+      hono: 4.11.7
 
   '@humanfs/core@0.19.1': {}
 
@@ -4330,9 +4324,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.3)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.3)
+      '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -4478,39 +4472,39 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solid-primitives/event-listener@2.4.3(solid-js@1.9.10)':
+  '@solid-primitives/event-listener@2.4.3(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.11)
+      solid-js: 1.9.11
 
-  '@solid-primitives/keyboard@1.3.3(solid-js@1.9.10)':
+  '@solid-primitives/keyboard@1.3.3(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
-      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.10)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.11)
+      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.11)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.11)
+      solid-js: 1.9.11
 
-  '@solid-primitives/resize-observer@2.1.3(solid-js@1.9.10)':
+  '@solid-primitives/resize-observer@2.1.3(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
-      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.10)
-      '@solid-primitives/static-store': 0.1.2(solid-js@1.9.10)
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.11)
+      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.11)
+      '@solid-primitives/static-store': 0.1.2(solid-js@1.9.11)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.11)
+      solid-js: 1.9.11
 
-  '@solid-primitives/rootless@1.5.2(solid-js@1.9.10)':
+  '@solid-primitives/rootless@1.5.2(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.11)
+      solid-js: 1.9.11
 
-  '@solid-primitives/static-store@0.1.2(solid-js@1.9.10)':
+  '@solid-primitives/static-store@0.1.2(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.11)
+      solid-js: 1.9.11
 
-  '@solid-primitives/utils@6.3.2(solid-js@1.9.10)':
+  '@solid-primitives/utils@6.3.2(solid-js@1.9.11)':
     dependencies:
-      solid-js: 1.9.10
+      solid-js: 1.9.11
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4605,11 +4599,11 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.0': {}
 
-  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@1.9.11)':
     dependencies:
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 1.9.10
+      solid-js: 1.9.11
     transitivePeerDependencies:
       - csstype
 
@@ -4631,17 +4625,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@tanstack/devtools@0.10.5(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools@0.10.5(csstype@3.2.3)(solid-js@1.9.11)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
-      '@solid-primitives/keyboard': 1.3.3(solid-js@1.9.10)
-      '@solid-primitives/resize-observer': 2.1.3(solid-js@1.9.10)
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.11)
+      '@solid-primitives/keyboard': 1.3.3(solid-js@1.9.11)
+      '@solid-primitives/resize-observer': 2.1.3(solid-js@1.9.11)
       '@tanstack/devtools-client': 0.0.5
       '@tanstack/devtools-event-bus': 0.4.0
-      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@1.9.11)
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 1.9.10
+      solid-js: 1.9.11
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -4669,9 +4663,9 @@ snapshots:
 
   '@tanstack/query-devtools@5.93.0': {}
 
-  '@tanstack/react-devtools@0.9.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)':
+  '@tanstack/react-devtools@0.9.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.11)':
     dependencies:
-      '@tanstack/devtools': 0.10.5(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools': 0.10.5(csstype@3.2.3)(solid-js@1.9.11)
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
       react: 19.2.4
@@ -5974,7 +5968,7 @@ snapshots:
 
   hls.js@1.6.15: {}
 
-  hono@4.11.3: {}
+  hono@4.11.7: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -6739,10 +6733,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.3.3(seroval@1.5.0):
-    dependencies:
-      seroval: 1.5.0
-
   seroval-plugins@1.5.0(seroval@1.5.0):
     dependencies:
       seroval: 1.5.0
@@ -6760,7 +6750,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.1(@types/node@25.1.0)(hono@4.11.3)(typescript@5.9.3):
+  shadcn@3.8.1(@types/node@25.1.0)(hono@4.11.7)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.29.0
@@ -6768,7 +6758,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.52.0
-      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -6848,11 +6838,11 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  solid-js@1.9.10:
+  solid-js@1.9.11:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.0
-      seroval-plugins: 1.3.3(seroval@1.5.0)
+      seroval-plugins: 1.5.0(seroval@1.5.0)
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/__tests__/properties/trickplay-utils.property.test.ts
+++ b/src/__tests__/properties/trickplay-utils.property.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Property-based tests for trickplay utilities.
+ */
+
+import { describe, expect, it } from 'vitest'
+import * as fc from 'fast-check'
+
+import type { TrickplayInfoDto } from '@/types/jellyfin'
+import type { TrickplayData } from '@/lib/trickplay-utils'
+import {
+  buildTrickplayTileUrl,
+  getBestTrickplayInfo,
+  getTrickplayPosition,
+} from '@/lib/trickplay-utils'
+
+/** Arbitrary for valid trickplay info */
+const trickplayInfoArb = fc.record({
+  Width: fc.integer({ min: 100, max: 640 }),
+  Height: fc.integer({ min: 56, max: 360 }),
+  TileWidth: fc.integer({ min: 1, max: 10 }),
+  TileHeight: fc.integer({ min: 1, max: 10 }),
+  ThumbnailCount: fc.integer({ min: 1, max: 1000 }),
+  Interval: fc.integer({ min: 1000, max: 30000 }),
+  Bandwidth: fc.integer({ min: 1000, max: 10000000 }),
+})
+
+/** Arbitrary for trickplay data structure */
+const trickplayDataArb = fc
+  .record({
+    mediaSourceId: fc.uuid(),
+    width: fc.integer({ min: 100, max: 640 }),
+    info: trickplayInfoArb,
+  })
+  .map(({ mediaSourceId, width, info }) => ({
+    [mediaSourceId]: {
+      [String(width)]: info,
+    },
+  }))
+
+describe('trickplay-utils', () => {
+  describe('getBestTrickplayInfo', () => {
+    it('returns null for undefined or null input', () => {
+      expect(getBestTrickplayInfo(undefined)).toBeNull()
+      expect(getBestTrickplayInfo(null)).toBeNull()
+    })
+
+    it('returns null for empty trickplay data', () => {
+      expect(getBestTrickplayInfo({})).toBeNull()
+    })
+
+    it('returns trickplay info for valid data', () => {
+      fc.assert(
+        fc.property(trickplayDataArb, (trickplay) => {
+          const result = getBestTrickplayInfo(trickplay)
+          expect(result).not.toBeNull()
+          expect(result?.mediaSourceId).toBeDefined()
+          expect(result?.info).toBeDefined()
+        }),
+      )
+    })
+
+    it('prefers width >= 320 when available', () => {
+      const trickplay: TrickplayData = {
+        'source-1': {
+          '160': { Width: 160, ThumbnailCount: 100, Interval: 10000 },
+          '320': { Width: 320, ThumbnailCount: 100, Interval: 10000 },
+          '640': { Width: 640, ThumbnailCount: 100, Interval: 10000 },
+        },
+      }
+      const result = getBestTrickplayInfo(trickplay)
+      expect(result?.info.Width).toBe(320)
+    })
+
+    it('uses largest available width if none >= 320', () => {
+      const trickplay: TrickplayData = {
+        'source-1': {
+          '160': { Width: 160, ThumbnailCount: 100, Interval: 10000 },
+          '240': { Width: 240, ThumbnailCount: 100, Interval: 10000 },
+        },
+      }
+      const result = getBestTrickplayInfo(trickplay)
+      expect(result?.info.Width).toBe(240)
+    })
+  })
+
+  describe('getTrickplayPosition', () => {
+    const baseInfo: TrickplayInfoDto = {
+      Width: 320,
+      Height: 180,
+      TileWidth: 5,
+      TileHeight: 5,
+      ThumbnailCount: 100,
+      Interval: 10000, // 10 seconds per thumbnail
+    }
+
+    it('returns null when required properties are missing', () => {
+      const incompleteInfo = { Width: 320 }
+      const result = getTrickplayPosition(
+        0,
+        incompleteInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).toBeNull()
+    })
+
+    it('calculates correct tile index for first thumbnail', () => {
+      const result = getTrickplayPosition(
+        0,
+        baseInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).not.toBeNull()
+      expect(result?.offsetX).toBe(0)
+      expect(result?.offsetY).toBe(0)
+      expect(result?.tileUrl).toContain('/0.jpg')
+    })
+
+    it('calculates correct position within first tile', () => {
+      // 15 seconds = thumbnail index 1 (10-20 seconds range)
+      // Position in tile: row 0, column 1
+      const result = getTrickplayPosition(
+        15,
+        baseInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).not.toBeNull()
+      expect(result?.offsetX).toBe(320) // 1 * 320
+      expect(result?.offsetY).toBe(0)
+    })
+
+    it('calculates correct row position', () => {
+      // 55 seconds = thumbnail index 5 (50-60 seconds range)
+      // 5 tiles per row, so index 5 is row 1, column 0
+      const result = getTrickplayPosition(
+        55,
+        baseInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).not.toBeNull()
+      expect(result?.offsetX).toBe(0)
+      expect(result?.offsetY).toBe(180) // 1 * 180
+    })
+
+    it('calculates correct tile image for later thumbnails', () => {
+      // 260 seconds = thumbnail index 26
+      // 25 thumbnails per tile (5x5), so index 26 is tile 1, position 1
+      const result = getTrickplayPosition(
+        260,
+        baseInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).not.toBeNull()
+      expect(result?.tileUrl).toContain('/1.jpg')
+      expect(result?.offsetX).toBe(320) // column 1
+      expect(result?.offsetY).toBe(0) // row 0
+    })
+
+    it('clamps to last thumbnail when time exceeds duration', () => {
+      // 2000 seconds with only 100 thumbnails, should clamp to index 99
+      const result = getTrickplayPosition(
+        2000,
+        baseInfo,
+        'item-1',
+        'source-1',
+        'http://localhost:8096',
+      )
+      expect(result).not.toBeNull()
+      // Index 99: tile 3 (99 / 25 = 3), position 24 in tile (99 % 25 = 24)
+      // Position 24: row 4, column 4 (24 / 5 = 4, 24 % 5 = 4)
+      expect(result?.tileUrl).toContain('/3.jpg')
+      expect(result?.offsetX).toBe(4 * 320)
+      expect(result?.offsetY).toBe(4 * 180)
+    })
+
+    it('property: thumbnail index increases monotonically with time', () => {
+      fc.assert(
+        fc.property(
+          fc.float({ min: 0, max: 1000, noNaN: true }),
+          fc.float({ min: 0, max: 1000, noNaN: true }),
+          (time1, time2) => {
+            if (time1 >= time2) return true // Skip when not increasing
+
+            const result1 = getTrickplayPosition(
+              time1,
+              baseInfo,
+              'item-1',
+              'source-1',
+              'http://localhost:8096',
+            )
+            const result2 = getTrickplayPosition(
+              time2,
+              baseInfo,
+              'item-1',
+              'source-1',
+              'http://localhost:8096',
+            )
+
+            if (!result1 || !result2) return true
+
+            // Extract tile index from URL
+            const getTileIndex = (url: string) => {
+              const match = url.match(/\/(\d+)\.jpg/)
+              return match ? parseInt(match[1], 10) : 0
+            }
+
+            const tile1 = getTileIndex(result1.tileUrl)
+            const tile2 = getTileIndex(result2.tileUrl)
+
+            // Tile index should be >= (can be same tile)
+            return tile2 >= tile1
+          },
+        ),
+      )
+    })
+
+    it('property: offset is always within tile bounds', () => {
+      fc.assert(
+        fc.property(
+          fc.float({ min: 0, max: 5000, noNaN: true }),
+          trickplayInfoArb,
+          (timeSeconds, info) => {
+            const result = getTrickplayPosition(
+              timeSeconds,
+              info,
+              'item-1',
+              'source-1',
+              'http://localhost:8096',
+            )
+
+            if (!result) return true // Skip invalid configs
+
+            const maxOffsetX = (info.TileWidth - 1) * info.Width
+            const maxOffsetY = (info.TileHeight - 1) * info.Height
+
+            return (
+              result.offsetX >= 0 &&
+              result.offsetX <= maxOffsetX &&
+              result.offsetY >= 0 &&
+              result.offsetY <= maxOffsetY
+            )
+          },
+        ),
+      )
+    })
+  })
+
+  describe('buildTrickplayTileUrl', () => {
+    it('builds correct URL without API key', () => {
+      const url = buildTrickplayTileUrl(
+        'http://localhost:8096',
+        'item-123',
+        320,
+        0,
+        'source-456',
+      )
+      expect(url).toBe(
+        'http://localhost:8096/Videos/item-123/Trickplay/320/0.jpg?mediaSourceId=source-456',
+      )
+    })
+
+    it('builds correct URL with API key', () => {
+      const url = buildTrickplayTileUrl(
+        'http://localhost:8096',
+        'item-123',
+        320,
+        5,
+        'source-456',
+        'my-api-key',
+      )
+      expect(url).toContain('api_key=my-api-key')
+      expect(url).toContain('mediaSourceId=source-456')
+      expect(url).toContain('/Trickplay/320/5.jpg')
+    })
+
+    it('handles trailing slash in server address', () => {
+      const url = buildTrickplayTileUrl(
+        'http://localhost:8096/',
+        'item-123',
+        320,
+        0,
+        'source-456',
+      )
+      // Should not have double slash
+      expect(url).not.toContain('8096//Videos')
+      expect(url).toBe(
+        'http://localhost:8096/Videos/item-123/Trickplay/320/0.jpg?mediaSourceId=source-456',
+      )
+    })
+
+    it('handles multiple trailing slashes', () => {
+      const url = buildTrickplayTileUrl(
+        'http://localhost:8096///',
+        'item-123',
+        320,
+        0,
+        'source-456',
+      )
+      // Should not have double slash
+      expect(url).not.toContain('//Videos')
+      expect(url).toContain('/Videos/')
+    })
+
+    it('property: URL always contains required path segments', () => {
+      fc.assert(
+        fc.property(
+          fc.webUrl(),
+          fc.uuid(),
+          fc.integer({ min: 100, max: 640 }),
+          fc.nat(100),
+          fc.uuid(),
+          fc.option(fc.string({ minLength: 1, maxLength: 64 })),
+          (server, itemId, width, tileIndex, mediaSourceId, apiKey) => {
+            const url = buildTrickplayTileUrl(
+              server,
+              itemId,
+              width,
+              tileIndex,
+              mediaSourceId,
+              apiKey ?? undefined,
+            )
+
+            return (
+              url.includes(
+                `/Videos/${itemId}/Trickplay/${width}/${tileIndex}.jpg`,
+              ) &&
+              url.includes(`mediaSourceId=${encodeURIComponent(mediaSourceId)}`)
+            )
+          },
+        ),
+      )
+    })
+
+    it('property: URL never has double slashes at server/path boundary', () => {
+      fc.assert(
+        fc.property(
+          // Generate server addresses with optional trailing slashes
+          fc
+            .tuple(
+              fc.constantFrom(
+                'http://localhost:8096',
+                'https://jellyfin.example.com',
+                'http://192.168.1.100:8096',
+              ),
+              fc.nat(5),
+            )
+            .map(([url, slashCount]) => url + '/'.repeat(slashCount)),
+          fc.uuid(),
+          fc.integer({ min: 100, max: 640 }),
+          fc.nat(100),
+          fc.uuid(),
+          (server, itemId, width, tileIndex, mediaSourceId) => {
+            const url = buildTrickplayTileUrl(
+              server,
+              itemId,
+              width,
+              tileIndex,
+              mediaSourceId,
+            )
+
+            // Check that there's no double slash between server address and /Videos
+            return !url.includes('//Videos')
+          },
+        ),
+      )
+    })
+  })
+})

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -18,7 +18,11 @@ import { useShallow } from 'zustand/shallow'
 import { PlayerScrubber } from './PlayerScrubber'
 import { PlayerControls } from './PlayerControls'
 import { initialPlayerState, playerReducer } from './player-reducer'
-import type { BaseItemDto, MediaSegmentType } from '@/types/jellyfin'
+import type {
+  BaseItemDto,
+  MediaSegmentDto,
+  MediaSegmentType,
+} from '@/types/jellyfin'
 import type {
   VideoPlayerError,
   VideoPlayerErrorType,
@@ -78,6 +82,7 @@ function findPreferredAudioStreamIndex(
 export interface PlayerProps {
   item: BaseItemDto
   timestamp?: number
+  segments?: Array<MediaSegmentDto>
   onCreateSegment: (data: CreateSegmentData) => void
   onUpdateSegmentTimestamp: (data: TimestampUpdate) => void
   className?: string
@@ -92,6 +97,7 @@ export interface PlayerProps {
 export function Player({
   item,
   timestamp,
+  segments,
   onCreateSegment,
   onUpdateSegmentTimestamp,
   className,
@@ -645,7 +651,11 @@ export function Player({
         currentTime={currentTime}
         duration={duration}
         buffered={buffered}
+        chapters={item.Chapters}
+        segments={segments}
         onSeek={handleSeek}
+        itemId={item.Id}
+        trickplay={item.Trickplay}
       />
 
       <PlayerControls

--- a/src/components/player/PlayerEditor.tsx
+++ b/src/components/player/PlayerEditor.tsx
@@ -477,6 +477,7 @@ export function PlayerEditor({
         <Player
           item={item}
           timestamp={playerTimestamp}
+          segments={editingSegments}
           onCreateSegment={handleCreateSegment}
           onUpdateSegmentTimestamp={handleUpdateSegmentTimestamp}
           getCurrentTimeRef={getCurrentTimeRef}

--- a/src/components/player/PlayerScrubber.tsx
+++ b/src/components/player/PlayerScrubber.tsx
@@ -111,7 +111,7 @@ export function PlayerScrubber({
       itemId,
       trickplayInfo.mediaSourceId,
       serverAddress,
-      apiKey ?? undefined,
+      apiKey,
     )
   }, [trickplayInfo, itemId, hoverTime, serverAddress, apiKey])
 
@@ -248,6 +248,11 @@ export function PlayerScrubber({
     if (!segments || segments.length === 0 || duration <= 0) return []
 
     return segments
+      .filter((segment) => {
+        const startSeconds = segment.StartTicks ?? 0
+        const startPercent = (startSeconds / duration) * 100
+        return startPercent < 100 // Filter out segments starting beyond 100%
+      })
       .map((segment) => {
         // StartTicks/EndTicks are already in seconds for editing segments
         const startSeconds = segment.StartTicks ?? 0
@@ -336,16 +341,27 @@ export function PlayerScrubber({
               left: `${marker.position}%`,
               transform: 'translate(-50%, -50%)',
             }}
-            onPointerEnter={() =>
+            role="button"
+            tabIndex={0}
+            aria-label={marker.name || `Chapter ${index + 1}`}
+            onPointerEnter={() => {
               setHoveredChapter({
                 name: marker.name,
                 position: marker.position,
               })
-            }
+              setHoverTime(null)
+            }}
             onPointerLeave={() => setHoveredChapter(null)}
             onClick={(e) => {
               e.stopPropagation()
               onSeek(marker.time)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                e.stopPropagation()
+                onSeek(marker.time)
+              }
             }}
             title={marker.name || `Chapter ${index + 1}`}
           />

--- a/src/components/player/PlayerScrubber.tsx
+++ b/src/components/player/PlayerScrubber.tsx
@@ -259,14 +259,17 @@ export function PlayerScrubber({
         const endSeconds = segment.EndTicks ?? 0
         const startPercent = (startSeconds / duration) * 100
         const endPercent = (endSeconds / duration) * 100
+        const clampedStart = Math.max(0, startPercent)
+        const clampedEnd = Math.min(100, endPercent)
+        const width = Math.max(0, clampedEnd - clampedStart)
         const colorConfig = segment.Type
           ? SEGMENT_COLORS[segment.Type]
           : DEFAULT_SEGMENT_COLOR
         return {
           id: segment.Id,
           type: segment.Type,
-          start: Math.max(0, startPercent),
-          width: Math.min(100 - startPercent, endPercent - startPercent),
+          start: clampedStart,
+          width,
           color: colorConfig.css,
         }
       })

--- a/src/lib/trickplay-utils.ts
+++ b/src/lib/trickplay-utils.ts
@@ -1,0 +1,170 @@
+/**
+ * Trickplay utilities for calculating thumbnail positions and URLs.
+ * Trickplay provides video preview thumbnails organized in tile images (sprite sheets).
+ */
+
+import type { TrickplayInfoDto } from '@/types/jellyfin'
+
+/** Structure for the trickplay data from BaseItemDto.Trickplay */
+export type TrickplayData = {
+  [mediaSourceId: string]: {
+    [width: string]: TrickplayInfoDto
+  }
+}
+
+/** Computed trickplay position for rendering */
+export interface TrickplayPosition {
+  /** URL to the tile image */
+  tileUrl: string
+  /** X position within the tile (in pixels) */
+  offsetX: number
+  /** Y position within the tile (in pixels) */
+  offsetY: number
+  /** Width of a single thumbnail */
+  thumbnailWidth: number
+  /** Height of a single thumbnail */
+  thumbnailHeight: number
+}
+
+/**
+ * Gets the best available trickplay info for an item.
+ * Prefers smaller widths for faster loading, returns the first media source.
+ */
+export function getBestTrickplayInfo(
+  trickplay: TrickplayData | null | undefined,
+): { mediaSourceId: string; info: TrickplayInfoDto } | null {
+  if (!trickplay) return null
+
+  const mediaSourceIds = Object.keys(trickplay)
+  if (mediaSourceIds.length === 0) return null
+
+  const mediaSourceId = mediaSourceIds[0]
+  const widthMap = trickplay[mediaSourceId]
+
+  const widths = Object.keys(widthMap)
+    .map(Number)
+    .filter((w) => !isNaN(w))
+    .sort((a, b) => a - b)
+
+  if (widths.length === 0) return null
+
+  // Prefer width around 320px for good quality/size balance
+  const preferredWidth =
+    widths.find((w) => w >= 320) ?? widths[widths.length - 1]
+  const info = widthMap[String(preferredWidth)]
+
+  return { mediaSourceId, info }
+}
+
+/**
+ * Calculates the trickplay position for a given time.
+ *
+ * @param timeSeconds - The current hover time in seconds
+ * @param info - The trickplay info containing tile dimensions and interval
+ * @param itemId - The item ID for URL construction
+ * @param mediaSourceId - The media source ID
+ * @param serverAddress - The Jellyfin server base URL
+ * @param apiKey - Optional API key for authentication
+ * @returns The trickplay position data for rendering, or null if unavailable
+ */
+export function getTrickplayPosition(
+  timeSeconds: number,
+  info: TrickplayInfoDto,
+  itemId: string,
+  mediaSourceId: string,
+  serverAddress: string,
+  apiKey?: string,
+): TrickplayPosition | null {
+  const {
+    Width: thumbnailWidth,
+    Height: thumbnailHeight,
+    TileWidth: tilesPerRow,
+    TileHeight: tilesPerColumn,
+    ThumbnailCount: totalThumbnails,
+    Interval: intervalMs,
+  } = info
+
+  // Validate required properties
+  if (
+    !thumbnailWidth ||
+    !thumbnailHeight ||
+    !tilesPerRow ||
+    !tilesPerColumn ||
+    !totalThumbnails ||
+    !intervalMs
+  ) {
+    return null
+  }
+
+  // Calculate which thumbnail index this time maps to
+  const thumbnailIndex = Math.min(
+    Math.floor((timeSeconds * 1000) / intervalMs),
+    totalThumbnails - 1,
+  )
+
+  if (thumbnailIndex < 0) return null
+
+  // Calculate thumbnails per tile
+  const thumbnailsPerTile = tilesPerRow * tilesPerColumn
+
+  // Calculate which tile image this thumbnail is in
+  const tileIndex = Math.floor(thumbnailIndex / thumbnailsPerTile)
+
+  // Calculate position within the tile
+  const positionInTile = thumbnailIndex % thumbnailsPerTile
+  const tileX = positionInTile % tilesPerRow
+  const tileY = Math.floor(positionInTile / tilesPerRow)
+
+  // Calculate pixel offsets
+  const offsetX = tileX * thumbnailWidth
+  const offsetY = tileY * thumbnailHeight
+
+  // Build the tile image URL
+  const tileUrl = buildTrickplayTileUrl(
+    serverAddress,
+    itemId,
+    thumbnailWidth,
+    tileIndex,
+    mediaSourceId,
+    apiKey,
+  )
+
+  return {
+    tileUrl,
+    offsetX,
+    offsetY,
+    thumbnailWidth,
+    thumbnailHeight,
+  }
+}
+
+/**
+ * Builds the URL for a trickplay tile image.
+ *
+ * @param serverAddress - The Jellyfin server base URL
+ * @param itemId - The item ID
+ * @param width - The trickplay resolution width
+ * @param tileIndex - The tile index (0-based)
+ * @param mediaSourceId - The media source ID
+ * @param apiKey - Optional API key for authentication
+ * @returns The complete URL to the tile image
+ */
+export function buildTrickplayTileUrl(
+  serverAddress: string,
+  itemId: string,
+  width: number,
+  tileIndex: number,
+  mediaSourceId: string,
+  apiKey?: string,
+): string {
+  // Remove trailing slash from serverAddress to prevent double slashes
+  const baseUrl = serverAddress.replace(/\/+$/, '')
+
+  const params = new URLSearchParams()
+  params.set('mediaSourceId', mediaSourceId)
+  if (apiKey) {
+    params.set('api_key', apiKey)
+  }
+
+  return `${baseUrl}/Videos/${itemId}/Trickplay/${width}/${tileIndex}.jpg?${params.toString()}`
+}

--- a/src/lib/trickplay-utils.ts
+++ b/src/lib/trickplay-utils.ts
@@ -28,7 +28,7 @@ export interface TrickplayPosition {
 
 /**
  * Gets the best available trickplay info for an item.
- * Prefers smaller widths for faster loading, returns the first media source.
+ * Prefers a width around 320px for a good quality/size balance (or the largest available width if none are ≥ 320), and returns the first media source.
  */
 export function getBestTrickplayInfo(
   trickplay: TrickplayData | null | undefined,

--- a/src/services/items/api.ts
+++ b/src/services/items/api.ts
@@ -67,6 +67,8 @@ const DETAIL_FIELDS = [
   ItemFields.Overview,
   ItemFields.People,
   ItemFields.Genres,
+  ItemFields.Chapters,
+  ItemFields.Trickplay,
 ] as const
 
 const SORT_ASCENDING = [SortOrder.Ascending] as const

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -5,6 +5,7 @@
 export type {
   BaseItemDto,
   MediaSegmentDto,
+  TrickplayInfoDto,
   VirtualFolderInfo,
   MediaSegmentsApiGetItemSegmentsRequest,
 } from '@jellyfin/sdk/lib/generated-client'


### PR DESCRIPTION
Introduces trickplay preview thumbnails on hover in the PlayerScrubber component using new utilities in src/lib/trickplay-utils.ts. Updates Player and PlayerEditor to pass segment and trickplay data, adds chapter and segment markers to the scrubber, and ensures required fields are fetched in the item API. Includes property-based tests for trickplay utilities.