### PR TITLE
Add frame-rate snapping and segment input fixes

### DIFF
--- a/src/__tests__/properties/strategy-selection.property.test.ts
+++ b/src/__tests__/properties/strategy-selection.property.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as fc from 'fast-check'
 import type { BaseItemDto } from '@/types/jellyfin'
+import type * as CompatibilityModule from '@/services/video/compatibility'
 import { extractMediaSourceInfo, getPlaybackConfig } from '@/services/video/api'
 import {
   DIRECT_PLAY_AUDIO_CODECS,
@@ -51,9 +52,7 @@ vi.mock('@/services/jellyfin', () => ({
 // In real browser, isCodecSupported would check actual browser capabilities
 // For testing, we mock checkCompatibility to return predictable results
 vi.mock('@/services/video/compatibility', async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  type CompatModule = typeof import('@/services/video/compatibility')
-  const original = await importOriginal<CompatModule>()
+  const original = await importOriginal<typeof CompatibilityModule>()
   return {
     ...original,
     checkCompatibility: vi.fn(

--- a/src/components/player/PlayerEditor.tsx
+++ b/src/components/player/PlayerEditor.tsx
@@ -626,7 +626,7 @@ function useRenderPlayerEditor({
           <div className="space-y-3">
             {editingSegments.map((segment, index) => (
               <div
-                key={`${segment.Id ?? `segment-${index}`}-${segment.StartTicks ?? 0}-${segment.EndTicks ?? 0}`}
+                key={segment.Id ?? `segment-${index}`}
                 style={{
                   contentVisibility: 'auto',
                   containIntrinsicSize: '0 280px',

--- a/src/lib/frame-rate-utils.ts
+++ b/src/lib/frame-rate-utils.ts
@@ -1,0 +1,46 @@
+import { parseFrameRate } from './time-utils'
+import type { BaseItemDto } from '@/types/jellyfin'
+
+type FrameRateField = 'RealFrameRate' | 'AverageFrameRate' | 'FrameRate'
+
+const FRAME_RATE_FIELDS: ReadonlyArray<FrameRateField> = [
+  'RealFrameRate',
+  'AverageFrameRate',
+  'FrameRate',
+]
+
+function readNumericLikeField(
+  source: unknown,
+  field: FrameRateField,
+): string | number | undefined {
+  if (!source || typeof source !== 'object') return undefined
+  const value = (source as Record<string, unknown>)[field]
+  if (typeof value === 'string' || typeof value === 'number') {
+    return value
+  }
+  return undefined
+}
+
+function isVideoStream(stream: unknown): boolean {
+  if (!stream || typeof stream !== 'object') return false
+  return (stream as Record<string, unknown>).Type === 'Video'
+}
+
+export function getFrameStepSeconds(item: BaseItemDto): number | undefined {
+  const mediaStreams = item.MediaSources?.[0]?.MediaStreams
+  if (!Array.isArray(mediaStreams) || mediaStreams.length === 0) {
+    return undefined
+  }
+
+  const videoStream = mediaStreams.find(isVideoStream)
+  if (!videoStream) return undefined
+
+  for (const field of FRAME_RATE_FIELDS) {
+    const fps = parseFrameRate(readNumericLikeField(videoStream, field))
+    if (fps && fps > 0) {
+      return 1 / fps
+    }
+  }
+
+  return undefined
+}

--- a/src/lib/frame-rate-utils.ts
+++ b/src/lib/frame-rate-utils.ts
@@ -37,7 +37,7 @@ export function getFrameStepSeconds(item: BaseItemDto): number | undefined {
 
   for (const field of FRAME_RATE_FIELDS) {
     const fps = parseFrameRate(readNumericLikeField(videoStream, field))
-    if (fps && fps > 0) {
+    if (fps !== null) {
       return 1 / fps
     }
   }

--- a/src/lib/keyboard-utils.ts
+++ b/src/lib/keyboard-utils.ts
@@ -54,9 +54,11 @@ export function handleRangeKeyboard(
 
   switch (key) {
     case 'ArrowLeft':
+    case 'ArrowDown':
       newValue = Math.max(min, value - step)
       break
     case 'ArrowRight':
+    case 'ArrowUp':
       newValue = Math.min(effectiveMax, value + step)
       break
     case 'Home':

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -162,3 +162,58 @@ export function parseTimeString(
 
   return clampToTimeRange(result)
 }
+
+/**
+ * Parses a frame rate value into frames per second.
+ * Supports numeric values and rational strings like "24000/1001".
+ * Returns null for invalid, zero, or negative values.
+ */
+export function parseFrameRate(
+  value: string | number | null | undefined,
+): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : null
+  }
+
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  if (trimmed.includes('/')) {
+    const [numeratorText, denominatorText] = trimmed.split('/', 2)
+    const numerator = Number(numeratorText)
+    const denominator = Number(denominatorText)
+    if (
+      Number.isFinite(numerator) &&
+      Number.isFinite(denominator) &&
+      numerator > 0 &&
+      denominator > 0
+    ) {
+      return numerator / denominator
+    }
+    return null
+  }
+
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * Snaps a timestamp to the nearest frame boundary.
+ * Returns the original value when frameStep is invalid.
+ */
+export function snapToFrame(
+  seconds: number,
+  frameStep: number | null | undefined,
+): number {
+  const safeSeconds = toSafeNumber(seconds)
+  const safeFrameStep = toSafeNumber(frameStep)
+
+  if (safeFrameStep <= 0) return safeSeconds
+
+  const frameIndex = Math.round(safeSeconds / safeFrameStep)
+  const snapped = frameIndex * safeFrameStep
+
+  return Number(snapped.toFixed(9))
+}


### PR DESCRIPTION
Add frame-rate utilities and frame snapping: introduce parseFrameRate, snapToFrame and getFrameStepSeconds to compute a frame-step (seconds) from item media streams. Improve SegmentSlider to use frame stepping (optional) and snapping: clamp/snap helpers, input drafting/formatting, adjustable numeric step, keyboard handling (include ArrowUp/ArrowDown), and stricter validation/commit flow to prevent invalid ranges. Update PlayerEditor to use the new frame step, pass it to SegmentSlider, and centralize import info suffix formatting. Small test typing update for the compatibility mock import. These changes improve frame-accurate editing, UX for numeric inputs, and robustness of segment updates.