### PR TITLE
Handle container items to browse children

### DIFF
--- a/src/lib/navigation-utils.ts
+++ b/src/lib/navigation-utils.ts
@@ -54,8 +54,7 @@ function asRouteArg<TConsumer extends RouteConsumer>(
  * its children rather than opening the player.
  */
 function isContainerItem(item: BaseItemDto): boolean {
-  if (item.IsFolder && CONTAINER_TYPES.has(item.Type ?? '')) return true
-  return false
+  return CONTAINER_TYPES.has(item.Type ?? '')
 }
 
 /**

--- a/src/lib/navigation-utils.ts
+++ b/src/lib/navigation-utils.ts
@@ -20,7 +20,7 @@ const ROUTE_MAP: Record<string, string> = {
  * Container types that should browse into their children
  * rather than opening the player/editor.
  */
-const CONTAINER_TYPES = new Set<string>([
+const CONTAINER_TYPES = new Set<BaseItemKind>([
   BaseItemKind.BoxSet,
   BaseItemKind.Folder,
   BaseItemKind.CollectionFolder,
@@ -54,7 +54,7 @@ function asRouteArg<TConsumer extends RouteConsumer>(
  * its children rather than opening the player.
  */
 function isContainerItem(item: BaseItemDto): boolean {
-  return CONTAINER_TYPES.has(item.Type ?? '')
+  return item.Type != null && CONTAINER_TYPES.has(item.Type)
 }
 
 /**

--- a/src/lib/navigation-utils.ts
+++ b/src/lib/navigation-utils.ts
@@ -17,12 +17,28 @@ const ROUTE_MAP: Record<string, string> = {
 } as const
 
 /**
+ * Container types that should browse into their children
+ * rather than opening the player/editor.
+ */
+const CONTAINER_TYPES = new Set<string>([
+  BaseItemKind.BoxSet,
+  BaseItemKind.Folder,
+  BaseItemKind.CollectionFolder,
+  BaseItemKind.Playlist,
+  BaseItemKind.AggregateFolder,
+  BaseItemKind.UserView,
+  BaseItemKind.PhotoAlbum,
+  BaseItemKind.ManualPlaylistsFolder,
+  BaseItemKind.PlaylistsFolder,
+])
+
+/**
  * Navigation route result type.
  */
 interface NavigationRoute {
   to: string
-  params: { itemId: string }
-  search?: { fetchSegments: string }
+  params?: { itemId: string }
+  search?: Record<string, string | undefined>
 }
 
 type RouteConsumer = (...args: Array<never>) => unknown
@@ -34,15 +50,34 @@ function asRouteArg<TConsumer extends RouteConsumer>(
 }
 
 /**
+ * Checks whether a media item is a container that should browse into
+ * its children rather than opening the player.
+ */
+function isContainerItem(item: BaseItemDto): boolean {
+  if (item.IsFolder && CONTAINER_TYPES.has(item.Type ?? '')) return true
+  return false
+}
+
+/**
  * Gets the navigation route for a media item based on its type.
- * Series, artists, and albums navigate to their detail views.
- * Other items navigate to the player with segment fetching enabled.
+ * - Container types (BoxSet, Folder, Playlist, etc.) browse into their children.
+ * - Series, artists, and albums navigate to their detail views.
+ * - Other items navigate to the player with segment fetching enabled.
  *
  * @param item - The media item to get navigation route for
  * @returns Navigation route configuration
  */
 function getNavigationRoute(item: BaseItemDto): NavigationRoute {
   const itemId = item.Id ?? ''
+
+  // Container items browse into their children on the index page
+  if (isContainerItem(item)) {
+    return {
+      to: '/',
+      search: { collection: itemId, page: undefined, search: undefined },
+    }
+  }
+
   const to = ROUTE_MAP[item.Type ?? ''] ?? '/player/$itemId'
   const isPlayable = !ROUTE_MAP[item.Type ?? '']
 

--- a/src/services/items/api.ts
+++ b/src/services/items/api.ts
@@ -125,7 +125,7 @@ export async function getItems(
         sortOrder: [...SORT_ASCENDING],
         isMissing: false,
         excludeItemTypes,
-        recursive: true,
+        recursive: !!searchTerm,
         fields: includeMediaStreams
           ? [ItemFields.MediaStreams, ItemFields.MediaSources]
           : undefined,

--- a/src/services/items/api.ts
+++ b/src/services/items/api.ts
@@ -125,7 +125,7 @@ export async function getItems(
         sortOrder: [...SORT_ASCENDING],
         isMissing: false,
         excludeItemTypes,
-        recursive: !!searchTerm,
+        recursive: true,
         fields: includeMediaStreams
           ? [ItemFields.MediaStreams, ItemFields.MediaSources]
           : undefined,


### PR DESCRIPTION
fix #69

## Summary by Sourcery

Adjust item navigation so container items browse into their children instead of opening the player, and ensure item retrieval is always recursive.

Bug Fixes:
- Fix navigation for folder-like media items so selecting them opens their child items instead of the player.
- Ensure item queries always search recursively to include content in nested containers.

Enhancements:
- Generalize navigation search parameters to support flexible query strings when routing to item collections.