### PR TITLE
Add getProviderIds and limit concurrency

### DIFF
--- a/src/components/player/PlayerEditor.tsx
+++ b/src/components/player/PlayerEditor.tsx
@@ -4,7 +4,6 @@
  */
 
 import * as React from 'react'
-import axios from 'axios'
 import { useTranslation } from 'react-i18next'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import { ClipboardPaste, Loader2, Save } from 'lucide-react'
@@ -39,6 +38,7 @@ import {
   parseProviderId,
 } from '@/services/skipme/api'
 import { showNotification } from '@/lib/notifications'
+import { getAxiosMessageKey } from '@/lib/error-utils'
 import { cn } from '@/lib/utils'
 import { useVibrantButtonStyle } from '@/hooks/use-vibrant-button-style'
 import {
@@ -674,14 +674,10 @@ function useRenderPlayerEditor({
           message: t('editor.share.success'),
         })
       } catch (e) {
-        let messageKey = 'editor.share.failed'
-        if (axios.isAxiosError(e)) {
-          if (e.response) {
-            if (e.response.status === 403) {
-              messageKey = 'editor.share.clientNotSupported'
-            }
-          }
-        }
+        const messageKey = getAxiosMessageKey(e, {
+          defaultKey: 'editor.share.failed',
+          forbiddenKey: 'editor.share.clientNotSupported',
+        })
         showNotification({
           type: 'negative',
           message: t(messageKey),

--- a/src/components/player/PlayerEditor.tsx
+++ b/src/components/player/PlayerEditor.tsx
@@ -15,6 +15,7 @@ import type {
   MediaSegmentDto,
   MediaSegmentType,
 } from '@/types/jellyfin'
+import { getProviderIds } from '@/types/jellyfin'
 import type {
   CreateSegmentData,
   SegmentUpdate,
@@ -31,6 +32,7 @@ import {
   introSkipperClipboardTextToSegments,
   segmentsToIntroSkipperClipboardText,
 } from '@/services/plugins/intro-skipper'
+import { getItemById } from '@/services/items/api'
 import {
   submitSegmentToSkipMe,
   toSkipMeSegmentType,
@@ -591,14 +593,17 @@ function useRenderPlayerEditor({
         return
       }
 
-      const providerIds = (item as { ProviderIds?: Record<string, string> })
-        .ProviderIds
+      const providerIds = getProviderIds(item)
 
       const tmdbId = parseProviderId(providerIds?.Tmdb)
       const tvdbId = parseProviderId(providerIds?.Tvdb)
       const aniListId = parseProviderId(providerIds?.AniList)
 
-      if (tmdbId === undefined && tvdbId === undefined && aniListId === undefined) {
+      if (
+        tmdbId === undefined &&
+        tvdbId === undefined &&
+        aniListId === undefined
+      ) {
         showNotification({
           type: 'negative',
           message: t('editor.share.noIds'),
@@ -638,14 +643,28 @@ function useRenderPlayerEditor({
         return
       }
 
+      // Fetch series/season TVDB IDs.
+      const seriesId = (item as { SeriesId?: string }).SeriesId
+      const seasonId = (item as { SeasonId?: string }).SeasonId
+      const [seriesItem, seasonItem] = await Promise.all([
+        seriesId ? getItemById(seriesId).catch(() => null) : null,
+        seasonId ? getItemById(seasonId).catch(() => null) : null,
+      ])
+      const tvdbSeriesId = parseProviderId(getProviderIds(seriesItem)?.Tvdb)
+      const tvdbSeasonId = parseProviderId(getProviderIds(seasonItem)?.Tvdb)
+      const seasonNum = item.ParentIndexNumber ?? undefined
+      const episodeNum = item.IndexNumber ?? undefined
+
       try {
         await submitSegmentToSkipMe({
           tmdb_id: tmdbId,
           tvdb_id: tvdbId,
           anilist_id: aniListId,
+          tvdb_series_id: tvdbSeriesId,
+          tvdb_season_id: tvdbSeasonId,
           segment: skipMeType,
-          season: item.ParentIndexNumber ?? undefined,
-          episode: item.IndexNumber ?? undefined,
+          season: seasonNum,
+          episode: episodeNum,
           duration_ms: durationMs,
           start_ms: startMs,
           end_ms: endMs,
@@ -655,14 +674,17 @@ function useRenderPlayerEditor({
           message: t('editor.share.success'),
         })
       } catch (e) {
-        const isForbidden = axios.isAxiosError(e) && e.response?.status === 403
+        let messageKey = 'editor.share.failed'
+        if (axios.isAxiosError(e)) {
+          if (e.response) {
+            if (e.response.status === 403) {
+              messageKey = 'editor.share.clientNotSupported'
+            }
+          }
+        }
         showNotification({
           type: 'negative',
-          message: t(
-            isForbidden
-              ? 'editor.share.clientNotSupported'
-              : 'editor.share.failed',
-          ),
+          message: t(messageKey),
         })
       }
     },

--- a/src/components/player/PlayerEditor.tsx
+++ b/src/components/player/PlayerEditor.tsx
@@ -36,6 +36,8 @@ import {
   submitSegmentToSkipMe,
   toSkipMeSegmentType,
   parseProviderId,
+  runTimeTicksToMs,
+  convertAndValidateSegmentTiming,
 } from '@/services/skipme/api'
 import { showNotification } from '@/lib/notifications'
 import { getAxiosMessageKey } from '@/lib/error-utils'
@@ -534,6 +536,11 @@ function useRenderPlayerEditor({
     }
   }, [t])
 
+  const dismissImportDialog = React.useCallback(() => {
+    pendingImportRef.current = null
+    setImportDialogOpen(false)
+  }, [])
+
   // Handle import confirmation: replace all segments
   const handleImportReplace = React.useCallback(() => {
     const pending = pendingImportRef.current
@@ -551,9 +558,8 @@ function useRenderPlayerEditor({
       message: `Replaced with ${pending.segments.length} segments${infoSuffix}`,
     })
 
-    pendingImportRef.current = null
-    setImportDialogOpen(false)
-  }, [updateEditingSegments])
+    dismissImportDialog()
+  }, [dismissImportDialog, updateEditingSegments])
 
   // Handle import confirmation: merge with existing segments
   const handleImportMerge = React.useCallback(() => {
@@ -571,15 +577,11 @@ function useRenderPlayerEditor({
       message: `Added ${pending.segments.length} segments${infoSuffix}`,
     })
 
-    pendingImportRef.current = null
-    setImportDialogOpen(false)
-  }, [updateEditingSegments])
+    dismissImportDialog()
+  }, [dismissImportDialog, updateEditingSegments])
 
   // Handle import dialog cancel
-  const handleImportCancel = React.useCallback(() => {
-    pendingImportRef.current = null
-    setImportDialogOpen(false)
-  }, [])
+  const handleImportCancel = dismissImportDialog
 
   // Share a segment to SkipMe.db
   const handleShareSegment = React.useCallback(
@@ -611,10 +613,8 @@ function useRenderPlayerEditor({
         return
       }
 
-      const durationMs = item.RunTimeTicks
-        ? Math.round(item.RunTimeTicks / 10_000)
-        : undefined
-      if (!durationMs || durationMs <= 0) {
+      const durationMs = runTimeTicksToMs(item.RunTimeTicks)
+      if (!durationMs) {
         showNotification({
           type: 'negative',
           message: t('editor.share.noDuration'),
@@ -624,40 +624,39 @@ function useRenderPlayerEditor({
 
       // StartTicks/EndTicks are stored in seconds by toUiSegment in the segment
       // API service layer. Convert to milliseconds for the SkipMe.db API.
-      const startMs = Math.round((segment.StartTicks ?? 0) * 1000)
-      const endMs = Math.round((segment.EndTicks ?? 0) * 1000)
-
-      if (startMs >= endMs) {
+      const timing = convertAndValidateSegmentTiming(
+        segment.StartTicks,
+        segment.EndTicks,
+        durationMs,
+      )
+      if (!timing.valid) {
         showNotification({
           type: 'negative',
-          message: t('editor.share.invalidTiming'),
+          message:
+            timing.reason === 'invalidTiming'
+              ? t('editor.share.invalidTiming')
+              : t('editor.share.exceedsDuration'),
         })
         return
       }
 
-      if (endMs > durationMs) {
-        showNotification({
-          type: 'negative',
-          message: t('editor.share.exceedsDuration'),
-        })
-        return
-      }
-
-      // Fetch series/season TVDB IDs.
-      const seriesId = (item as { SeriesId?: string }).SeriesId
-      const seasonId = (item as { SeasonId?: string }).SeasonId
+      // Fetch series/season provider IDs for TVDB and TMDB fallback.
+      const seriesId = item.SeriesId ?? undefined
+      const seasonId = item.SeasonId ?? undefined
       const [seriesItem, seasonItem] = await Promise.all([
         seriesId ? getItemById(seriesId).catch(() => null) : null,
         seasonId ? getItemById(seasonId).catch(() => null) : null,
       ])
-      const tvdbSeriesId = parseProviderId(getProviderIds(seriesItem)?.Tvdb)
+      const seriesProviderIds = getProviderIds(seriesItem)
+      const tvdbSeriesId = parseProviderId(seriesProviderIds?.Tvdb)
       const tvdbSeasonId = parseProviderId(getProviderIds(seasonItem)?.Tvdb)
+      const effectiveTmdbId = tmdbId ?? parseProviderId(seriesProviderIds?.Tmdb)
       const seasonNum = item.ParentIndexNumber ?? undefined
       const episodeNum = item.IndexNumber ?? undefined
 
       try {
         await submitSegmentToSkipMe({
-          tmdb_id: tmdbId,
+          tmdb_id: effectiveTmdbId,
           tvdb_id: tvdbId,
           anilist_id: aniListId,
           tvdb_series_id: tvdbSeriesId,
@@ -666,8 +665,8 @@ function useRenderPlayerEditor({
           season: seasonNum,
           episode: episodeNum,
           duration_ms: durationMs,
-          start_ms: startMs,
-          end_ms: endMs,
+          start_ms: timing.startMs,
+          end_ms: timing.endMs,
         })
         showNotification({
           type: 'positive',
@@ -846,7 +845,7 @@ function useRenderPlayerEditor({
         </button>
         <button
           data-interactive-transition="true"
-          onClick={handleSaveAll}
+          onClick={() => void handleSaveAll()}
           disabled={isSaving}
           aria-label={t('editor.saveSegment', 'Save all segments')}
           aria-busy={isSaving}

--- a/src/components/segment/SegmentSlider.tsx
+++ b/src/components/segment/SegmentSlider.tsx
@@ -521,9 +521,10 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
     setIsSharing(true)
     try {
       await onShare(segmentToShare)
-    } finally {
-      setIsSharing(false)
+    } catch {
+      // Error handling is done by the onShare callback itself
     }
+    setIsSharing(false)
   }, [formValues, isSharing, onShare, runtimeSeconds, segment])
 
   const handleDelete = React.useCallback(

--- a/src/components/segment/SegmentSlider.tsx
+++ b/src/components/segment/SegmentSlider.tsx
@@ -299,11 +299,26 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
     [segment, onUpdate],
   )
 
-  const handlePointerDown = React.useCallback(
-    (handle: 'start' | 'end') => (e: React.PointerEvent) => {
+  const handleStartPointerDown = React.useCallback(
+    (e: React.PointerEvent) => {
       e.preventDefault()
       e.stopPropagation()
-      setIsDragging(handle)
+      setIsDragging('start')
+      onSetActive(index)
+
+      const captureTarget = e.currentTarget as HTMLElement
+      captureTarget.setPointerCapture(e.pointerId)
+      pointerCaptureTargetRef.current = captureTarget
+      pointerIdRef.current = e.pointerId
+    },
+    [index, onSetActive],
+  )
+
+  const handleEndPointerDown = React.useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging('end')
       onSetActive(index)
 
       const captureTarget = e.currentTarget as HTMLElement
@@ -487,9 +502,9 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
       formValues,
       runtimeSeconds,
     )
-    const segmentToCopy = nextSegment.success ? nextSegment.segment : segment
+    const resolvedSegment = nextSegment.success ? nextSegment.segment : segment
     try {
-      const result = segmentsToIntroSkipperClipboardText([segmentToCopy])
+      const result = segmentsToIntroSkipperClipboardText([resolvedSegment])
       await navigator.clipboard.writeText(result.text)
       showNotification({
         type: 'positive',
@@ -517,15 +532,17 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
       formValues,
       runtimeSeconds,
     )
-    const segmentToShare = nextSegment.success ? nextSegment.segment : segment
+    const resolvedSegment = nextSegment.success ? nextSegment.segment : segment
     setIsSharing(true)
     try {
-      await onShare(segmentToShare)
+      await onShare(resolvedSegment)
     } catch {
       // Error handling is done by the onShare callback itself
     }
     setIsSharing(false)
   }, [formValues, isSharing, onShare, runtimeSeconds, segment])
+
+  const handleEdit = React.useCallback(() => onEdit?.(index), [index, onEdit])
 
   const handleDelete = React.useCallback(
     () => onDelete(index),
@@ -779,7 +796,7 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
             <Button
               variant="ghost"
               size="icon-sm"
-              onClick={() => onEdit(index)}
+              onClick={handleEdit}
               aria-label={t('segment.edit')}
               className="hover:bg-primary/10"
             >
@@ -843,7 +860,7 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
             aria-valuetext={formatTime(localStart)}
             aria-orientation="horizontal"
             tabIndex={0}
-            onPointerDown={handlePointerDown('start')}
+            onPointerDown={handleStartPointerDown}
             onKeyDown={handleStartKeyDown}
             onBlur={() => handleHandleBlur('start')}
           >
@@ -866,7 +883,7 @@ export const SegmentSlider = React.memo(function SegmentSliderComponent({
             aria-valuetext={formatTime(localEnd)}
             aria-orientation="horizontal"
             tabIndex={0}
-            onPointerDown={handlePointerDown('end')}
+            onPointerDown={handleEndPointerDown}
             onKeyDown={handleEndKeyDown}
             onBlur={() => handleHandleBlur('end')}
           >

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -10,6 +10,7 @@ import { AlertCircle, Loader2, Play, Share2 } from 'lucide-react'
 import axios from 'axios'
 
 import type { BaseItemDto, MediaSegmentDto } from '@/types/jellyfin'
+import { getProviderIds } from '@/types/jellyfin'
 import type { VibrantColors } from '@/hooks/use-vibrant-color'
 import { useEpisodes } from '@/hooks/queries/use-items'
 import { useVibrantTabStyle } from '@/hooks/use-vibrant-button-style'
@@ -25,12 +26,8 @@ import { cn } from '@/lib/utils'
 import { showNotification } from '@/lib/notifications'
 import { getEpisodes } from '@/services/items/api'
 import { getSegmentsById } from '@/services/segments/api'
-import {
-  submitCollectionToSkipMe,
-  toSkipMeSegmentType,
-  parseProviderId,
-  type SkipMeSubmitRequest,
-} from '@/services/skipme/api'
+import { submitCollectionToSkipMe, toSkipMeSegmentType, parseProviderId } from '@/services/skipme/api';
+import type { SkipMeSubmitRequest } from '@/services/skipme/api';
 
 interface SeriesViewProps {
   /** The series item */
@@ -305,7 +302,35 @@ interface EpisodeEntry {
   season: BaseItemDto
 }
 
-/** Fetch all episodes for every valid season in parallel, then all their segments in parallel. */
+/** Maximum number of concurrent API requests to Jellyfin when fetching episode/segment data. */
+const MAX_CONCURRENCY = 6
+
+/**
+ * Run an array of async tasks with bounded concurrency.
+ * Preserves input order in the returned results.
+ */
+async function mapWithLimit<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const i = nextIndex++
+      results[i] = await fn(items[i])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  )
+  return results
+}
+
+/** Fetch all episodes for every valid season, then all their segments, with bounded concurrency. */
 async function fetchSeriesEpisodeData(
   seriesId: string,
   validSeasons: Array<BaseItemDto>,
@@ -313,16 +338,20 @@ async function fetchSeriesEpisodeData(
   episodeEntries: Array<EpisodeEntry>
   segmentsPerEpisode: Array<Array<MediaSegmentDto>>
 }> {
-  const episodesPerSeason = await Promise.all(
-    validSeasons.map((season) => getEpisodes(seriesId, season.Id!)),
+  const episodesPerSeason = await mapWithLimit(
+    validSeasons,
+    MAX_CONCURRENCY,
+    (season) => getEpisodes(seriesId, season.Id!),
   )
   const episodeEntries = episodesPerSeason.flatMap((episodes, i) =>
     episodes
       .filter((e) => !!e.Id)
-      .map((episode) => ({ episode, season: validSeasons[i]! })),
+      .map((episode) => ({ episode, season: validSeasons[i] })),
   )
-  const segmentsPerEpisode = await Promise.all(
-    episodeEntries.map(({ episode }) => getSegmentsById(episode.Id!)),
+  const segmentsPerEpisode = await mapWithLimit(
+    episodeEntries,
+    MAX_CONCURRENCY,
+    ({ episode }) => getSegmentsById(episode.Id!),
   )
   return { episodeEntries, segmentsPerEpisode }
 }
@@ -340,14 +369,10 @@ function buildSubmitRequests(
   for (const [i, { episode, season }] of episodeEntries.entries()) {
     const segments = segmentsPerEpisode[i] ?? []
 
-    const seasonProviderIds = (
-      season as { ProviderIds?: Record<string, string> }
-    ).ProviderIds
+    const seasonProviderIds = getProviderIds(season)
     const tvdbSeasonId = parseProviderId(seasonProviderIds?.Tvdb)
 
-    const episodeProviderIds = (
-      episode as { ProviderIds?: Record<string, string> }
-    ).ProviderIds
+    const episodeProviderIds = getProviderIds(episode)
     const episodeTvdbId = parseProviderId(episodeProviderIds?.Tvdb)
 
     if (
@@ -397,6 +422,36 @@ function buildSubmitRequests(
 // SubmitAllButton - Submits all series segments to SkipMe.db
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Show the appropriate notification after a collection submission. */
+function notifyCollectionResult(
+  result: { ok: boolean; submitted?: number },
+  totalCount: number,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): void {
+  if (!result.ok) {
+    showNotification({
+      type: 'negative',
+      message: t('series.submitAllFailed'),
+    })
+    return
+  }
+  const submitted = result.submitted
+  if (submitted !== undefined && submitted < totalCount) {
+    showNotification({
+      type: 'warning',
+      message: t('series.submitAllPartial', {
+        submitted,
+        count: totalCount,
+      }),
+    })
+    return
+  }
+  showNotification({
+    type: 'positive',
+    message: t('series.submitAllSuccess', { count: totalCount }),
+  })
+}
+
 interface SubmitAllButtonProps {
   series: BaseItemDto
   seasons: Array<BaseItemDto>
@@ -409,16 +464,15 @@ function SubmitAllButton({ series, seasons }: SubmitAllButtonProps) {
   const handleSubmitAll = React.useCallback(async () => {
     if (!series.Id) return
     setIsSubmitting(true)
+
+    // Hoist value-block expressions out of try/catch for React Compiler
+    const seriesProviderIds = getProviderIds(series)
+    const seriesTmdbId = parseProviderId(seriesProviderIds?.Tmdb)
+    const seriesTvdbId = parseProviderId(seriesProviderIds?.Tvdb)
+    const seriesAniListId = parseProviderId(seriesProviderIds?.AniList)
+    const validSeasons = seasons.filter((s) => !!s.Id)
+
     try {
-      const seriesProviderIds = (
-        series as { ProviderIds?: Record<string, string> }
-      ).ProviderIds
-
-      const seriesTmdbId = parseProviderId(seriesProviderIds?.Tmdb)
-      const seriesTvdbId = parseProviderId(seriesProviderIds?.Tvdb)
-      const seriesAniListId = parseProviderId(seriesProviderIds?.AniList)
-
-      const validSeasons = seasons.filter((s) => !!s.Id)
       const { episodeEntries, segmentsPerEpisode } =
         await fetchSeriesEpisodeData(series.Id, validSeasons)
 
@@ -435,45 +489,27 @@ function SubmitAllButton({ series, seasons }: SubmitAllButtonProps) {
           type: 'warning',
           message: t('series.submitAllNone'),
         })
+        setIsSubmitting(false)
         return
       }
 
       const result = await submitCollectionToSkipMe(requests)
-      if (!result.ok) {
-        showNotification({
-          type: 'negative',
-          message: t('series.submitAllFailed'),
-        })
-      } else if (
-        result.submitted !== undefined &&
-        result.submitted < requests.length
-      ) {
-        showNotification({
-          type: 'warning',
-          message: t('series.submitAllPartial', {
-            submitted: result.submitted,
-            count: requests.length,
-          }),
-        })
-      } else {
-        showNotification({
-          type: 'positive',
-          message: t('series.submitAllSuccess', { count: requests.length }),
-        })
-      }
+      notifyCollectionResult(result, requests.length, t)
     } catch (e) {
-      const isForbidden = axios.isAxiosError(e) && e.response?.status === 403
+      let messageKey = 'series.submitAllFailed'
+      if (axios.isAxiosError(e)) {
+        if (e.response) {
+          if (e.response.status === 403) {
+            messageKey = 'series.submitAllClientNotSupported'
+          }
+        }
+      }
       showNotification({
         type: 'negative',
-        message: t(
-          isForbidden
-            ? 'series.submitAllClientNotSupported'
-            : 'series.submitAllFailed',
-        ),
+        message: t(messageKey),
       })
-    } finally {
-      setIsSubmitting(false)
     }
+    setIsSubmitting(false)
   }, [series, seasons, t])
 
   return (

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -7,7 +7,6 @@ import * as React from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { AlertCircle, Loader2, Play, Share2 } from 'lucide-react'
-import axios from 'axios'
 
 import type { BaseItemDto, MediaSegmentDto } from '@/types/jellyfin'
 import { getProviderIds } from '@/types/jellyfin'
@@ -22,12 +21,18 @@ import {
   ErrorState,
   LoadingState,
 } from '@/components/ui/async-state'
+import { mapWithLimit } from '@/lib/async-utils'
 import { cn } from '@/lib/utils'
+import { getAxiosMessageKey } from '@/lib/error-utils'
 import { showNotification } from '@/lib/notifications'
 import { getEpisodes } from '@/services/items/api'
 import { getSegmentsById } from '@/services/segments/api'
-import { submitCollectionToSkipMe, toSkipMeSegmentType, parseProviderId } from '@/services/skipme/api';
-import type { SkipMeSubmitRequest } from '@/services/skipme/api';
+import {
+  submitCollectionToSkipMe,
+  toSkipMeSegmentType,
+  parseProviderId,
+} from '@/services/skipme/api'
+import type { SkipMeSubmitRequest } from '@/services/skipme/api'
 
 interface SeriesViewProps {
   /** The series item */
@@ -305,31 +310,6 @@ interface EpisodeEntry {
 /** Maximum number of concurrent API requests to Jellyfin when fetching episode/segment data. */
 const MAX_CONCURRENCY = 6
 
-/**
- * Run an array of async tasks with bounded concurrency.
- * Preserves input order in the returned results.
- */
-async function mapWithLimit<T, R>(
-  items: ReadonlyArray<T>,
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<Array<R>> {
-  const results = new Array<R>(items.length)
-  let nextIndex = 0
-
-  async function worker() {
-    while (nextIndex < items.length) {
-      const i = nextIndex++
-      results[i] = await fn(items[i])
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
-  )
-  return results
-}
-
 /** Fetch all episodes for every valid season, then all their segments, with bounded concurrency. */
 async function fetchSeriesEpisodeData(
   seriesId: string,
@@ -496,14 +476,10 @@ function SubmitAllButton({ series, seasons }: SubmitAllButtonProps) {
       const result = await submitCollectionToSkipMe(requests)
       notifyCollectionResult(result, requests.length, t)
     } catch (e) {
-      let messageKey = 'series.submitAllFailed'
-      if (axios.isAxiosError(e)) {
-        if (e.response) {
-          if (e.response.status === 403) {
-            messageKey = 'series.submitAllClientNotSupported'
-          }
-        }
-      }
+      const messageKey = getAxiosMessageKey(e, {
+        defaultKey: 'series.submitAllFailed',
+        forbiddenKey: 'series.submitAllClientNotSupported',
+      })
       showNotification({
         type: 'negative',
         message: t(messageKey),

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -31,6 +31,8 @@ import {
   submitCollectionToSkipMe,
   toSkipMeSegmentType,
   parseProviderId,
+  runTimeTicksToMs,
+  convertAndValidateSegmentTiming,
 } from '@/services/skipme/api'
 import type { SkipMeSubmitRequest } from '@/services/skipme/api'
 
@@ -363,21 +365,19 @@ function buildSubmitRequests(
       continue
     }
 
-    const durationMs = episode.RunTimeTicks
-      ? Math.round(episode.RunTimeTicks / 10_000)
-      : undefined
-    if (!durationMs || durationMs <= 0) continue
+    const durationMs = runTimeTicksToMs(episode.RunTimeTicks)
+    if (!durationMs) continue
 
     for (const segment of segments) {
       const skipMeType = toSkipMeSegmentType(segment.Type)
       if (!skipMeType) continue
 
-      // StartTicks/EndTicks are stored in seconds by toUiSegment in the
-      // segment API service layer. Convert to milliseconds for SkipMe.db.
-      const startMs = Math.round((segment.StartTicks ?? 0) * 1000)
-      const endMs = Math.round((segment.EndTicks ?? 0) * 1000)
-
-      if (startMs >= endMs || endMs > durationMs) continue
+      const timing = convertAndValidateSegmentTiming(
+        segment.StartTicks,
+        segment.EndTicks,
+        durationMs,
+      )
+      if (!timing.valid) continue
 
       requests.push({
         tmdb_id: seriesTmdbId,
@@ -389,8 +389,8 @@ function buildSubmitRequests(
         season: episode.ParentIndexNumber ?? undefined,
         episode: episode.IndexNumber ?? undefined,
         duration_ms: durationMs,
-        start_ms: startMs,
-        end_ms: endMs,
+        start_ms: timing.startMs,
+        end_ms: timing.endMs,
       })
     }
   }

--- a/src/lib/async-utils.ts
+++ b/src/lib/async-utils.ts
@@ -19,6 +19,9 @@ export async function mapWithLimit<T, R>(
   limit: number,
   fn: (item: T) => Promise<R>,
 ): Promise<Array<R>> {
+  if (items.length === 0) return []
+  const effectiveLimit = Math.max(1, limit)
+
   const results = new Array<R>(items.length)
   let nextIndex = 0
 
@@ -30,7 +33,9 @@ export async function mapWithLimit<T, R>(
   }
 
   await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+    Array.from({ length: Math.min(effectiveLimit, items.length) }, () =>
+      worker(),
+    ),
   )
   return results
 }

--- a/src/lib/async-utils.ts
+++ b/src/lib/async-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Async Utilities
+ *
+ * Shared helpers for bounded-concurrency async operations.
+ *
+ * @module lib/async-utils
+ */
+
+/**
+ * Run an array of async tasks with bounded concurrency.
+ * Preserves input order in the returned results.
+ *
+ * @param items - Items to process
+ * @param limit - Maximum number of tasks running at once
+ * @param fn - Async function to apply to each item
+ */
+export async function mapWithLimit<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const i = nextIndex++
+      results[i] = await fn(items[i])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  )
+  return results
+}

--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -6,6 +6,8 @@
  * @module lib/error-utils
  */
 
+import axios from 'axios'
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Network Error Detection
 // ─────────────────────────────────────────────────────────────────────────────
@@ -62,4 +64,36 @@ export function getErrorSuggestion(error: string): string {
     return 'The server took too long to respond. Try again or check if the server is busy.'
   }
   return 'Please verify your input and try again.'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Axios Error Classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AxiosMessageKeyOptions {
+  /** Translation key returned for non-Axios or non-403 errors. */
+  defaultKey: string
+  /** Translation key returned when the server responds with 403 Forbidden. */
+  forbiddenKey: string
+}
+
+/**
+ * Maps an Axios error to a translation key based on HTTP status.
+ * Returns `forbiddenKey` for 403 responses, `defaultKey` otherwise.
+ *
+ * Structured to avoid value-block expressions (ternaries, optional chaining)
+ * so the result can be used inside a React Compiler-compatible try/catch.
+ */
+export function getAxiosMessageKey(
+  error: unknown,
+  { defaultKey, forbiddenKey }: AxiosMessageKeyOptions,
+): string {
+  if (axios.isAxiosError(error)) {
+    if (error.response) {
+      if (error.response.status === 403) {
+        return forbiddenKey
+      }
+    }
+  }
+  return defaultKey
 }

--- a/src/services/items/api.ts
+++ b/src/services/items/api.ts
@@ -204,7 +204,11 @@ export async function getEpisodes(
         seriesId,
         seasonId,
         isMissing: false,
-        fields: [ItemFields.MediaStreams, ItemFields.MediaSources, ItemFields.ProviderIds],
+        fields: [
+          ItemFields.MediaStreams,
+          ItemFields.MediaSources,
+          ItemFields.ProviderIds,
+        ],
         limit: options?.limit,
         startIndex: options?.startIndex,
       },

--- a/src/services/skipme/api.ts
+++ b/src/services/skipme/api.ts
@@ -44,6 +44,38 @@ export function toSkipMeSegmentType(type: string | undefined): string | null {
   return SKIPME_TYPE_MAP[type] ?? null
 }
 
+/**
+ * Converts Jellyfin RunTimeTicks to milliseconds.
+ * Returns undefined if the value is missing or non-positive.
+ */
+export function runTimeTicksToMs(
+  runTimeTicks: number | null | undefined,
+): number | undefined {
+  if (!runTimeTicks) return undefined
+  const ms = Math.round(runTimeTicks / 10_000)
+  return ms > 0 ? ms : undefined
+}
+
+/**
+ * Converts segment ticks (stored in seconds by toUiSegment) to milliseconds
+ * and validates the result against the episode duration.
+ *
+ * Returns `{ valid: false }` when timing is invalid, otherwise the converted values.
+ */
+export function convertAndValidateSegmentTiming(
+  startTicks: number | null | undefined,
+  endTicks: number | null | undefined,
+  durationMs: number,
+):
+  | { valid: false; reason: 'invalidTiming' | 'exceedsDuration' }
+  | { valid: true; startMs: number; endMs: number } {
+  const startMs = Math.round((startTicks ?? 0) * 1000)
+  const endMs = Math.round((endTicks ?? 0) * 1000)
+  if (startMs >= endMs) return { valid: false, reason: 'invalidTiming' }
+  if (endMs > durationMs) return { valid: false, reason: 'exceedsDuration' }
+  return { valid: true, startMs, endMs }
+}
+
 export interface SkipMeSubmitRequest {
   tmdb_id?: number
   tvdb_id?: number

--- a/src/services/skipme/api.ts
+++ b/src/services/skipme/api.ts
@@ -58,7 +58,7 @@ export interface SkipMeSubmitRequest {
   end_ms: number
 }
 
-export interface SkipMeSubmitResponse {
+interface SkipMeSubmitResponse {
   ok: boolean
   submission?: {
     id: string
@@ -66,7 +66,7 @@ export interface SkipMeSubmitResponse {
   }
 }
 
-export interface SkipMeCollectionSubmitResponse {
+interface SkipMeCollectionSubmitResponse {
   ok: boolean
   submitted?: number
 }

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -13,3 +13,22 @@ export {
   ImageType,
   MediaSegmentType,
 } from '@jellyfin/sdk/lib/generated-client'
+
+/**
+ * Safely extracts ProviderIds from a BaseItemDto.
+ *
+ * The Jellyfin SDK types `ProviderIds` as `{ [key: string]: string | null } | null | undefined`
+ * which requires a cast for convenient `?.Tmdb` style access. This helper centralises that
+ * cast so consumers don't repeat it.
+ */
+export function getProviderIds(
+  item:
+    | { ProviderIds?: Record<string, string | null> | null }
+    | null
+    | undefined,
+): Record<string, string> | undefined {
+  return (
+    (item as { ProviderIds?: Record<string, string> } | undefined)
+      ?.ProviderIds ?? undefined
+  )
+}

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -15,11 +15,10 @@ export {
 } from '@jellyfin/sdk/lib/generated-client'
 
 /**
- * Safely extracts ProviderIds from a BaseItemDto.
+ * Safely extracts ProviderIds from a BaseItemDto, filtering out null values.
  *
- * The Jellyfin SDK types `ProviderIds` as `{ [key: string]: string | null } | null | undefined`
- * which requires a cast for convenient `?.Tmdb` style access. This helper centralises that
- * cast so consumers don't repeat it.
+ * The Jellyfin SDK types `ProviderIds` as `{ [key: string]: string | null } | null | undefined`.
+ * This helper filters out nullish values so callers can safely assume all values are strings.
  */
 export function getProviderIds(
   item:
@@ -27,8 +26,16 @@ export function getProviderIds(
     | null
     | undefined,
 ): Record<string, string> | undefined {
-  return (
-    (item as { ProviderIds?: Record<string, string> } | undefined)
-      ?.ProviderIds ?? undefined
-  )
+  const raw = (
+    item as { ProviderIds?: Record<string, string | null> } | undefined
+  )?.ProviderIds
+  if (!raw) return undefined
+
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (value != null) {
+      result[key] = value
+    }
+  }
+  return result
 }

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -26,9 +26,7 @@ export function getProviderIds(
     | null
     | undefined,
 ): Record<string, string> | undefined {
-  const raw = (
-    item as { ProviderIds?: Record<string, string | null> } | undefined
-  )?.ProviderIds
+  const raw = item?.ProviderIds
   if (!raw) return undefined
 
   const result: Record<string, string> = {}
@@ -37,5 +35,5 @@ export function getProviderIds(
       result[key] = value
     }
   }
-  return result
+  return Object.keys(result).length > 0 ? result : undefined
 }


### PR DESCRIPTION
Introduce getProviderIds helper to safely access ProviderIds and replace ad-hoc casts across the codebase (PlayerEditor, SeriesView). Fetch series/season items in PlayerEditor to include TVDB series/season IDs when submitting to SkipMe and improve Axios error handling for clearer notification messages. In SeriesView add a bounded concurrency runner (mapWithLimit) and MAX_CONCURRENCY to avoid too many parallel Jellyfin requests, refactor episode/segment fetching to use it, and centralize collection-result notifications. Fix SegmentSlider state handling around sharing, adjust SubmitAllButton flow to ensure proper isSubmitting semantics, and make small typing/formatting tweaks in items/api and skipme/api.

## Summary by Sourcery

Limit concurrency and improve error handling for SkipMe submissions while centralizing ID/timing utilities and notification logic.

New Features:
- Add a bounded-concurrency async helper and use it for fetching series episodes and segments.
- Include TVDB series/season IDs and improved provider ID handling when sharing or submitting segments to SkipMe.

Bug Fixes:
- Fix SegmentSlider state handling around sharing and pointer events to avoid inconsistent UI state.
- Ensure SubmitAllButton correctly manages isSubmitting state even when returning early.

Enhancements:
- Introduce shared utilities for converting runtime ticks and validating segment timing against media duration.
- Centralize extraction of Jellyfin ProviderIds into a reusable helper that filters out null values.
- Refine SeriesView collection submission flow with shared notification logic and consistent isSubmitting handling.
- Improve SegmentSlider interaction and sharing behavior to better manage dragging, editing, and in-flight share state.
- Tighten typing and internal visibility for SkipMe API response types and item fetching fields.