### PR TITLE
feat: add frame-by-frame player shortcuts (#120)

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # required for `diff`
-      - uses: millionco/react-doctor@main
+      - uses: millionco/react-doctor@7db0805e98fc9be991bb05f29fbbb5a022bb4c21
         with:
           diff: master
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -3,7 +3,7 @@ name: React Doctor
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.13(@types/node@25.8.0)(jiti@2.7.0)(terser@5.47.1))
       '@tanstack/react-devtools':
         specifier: ^0.10.5
-        version: 0.10.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)
+        version: 0.10.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)
       '@tanstack/react-query-devtools':
         specifier: ^5.100.10
         version: 5.100.10(@tanstack/react-query@5.100.10(react@19.2.6))(react@19.2.6)
@@ -1102,48 +1102,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.120.0':
     resolution: {integrity: sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.120.0':
     resolution: {integrity: sha512-T/kZuU0ajop0xhzVMwH5r3srC9Nqup5HaIo+3uFjIN5uPxa0LvSxC1ZqP4aQGJVW5G0z8/nCkjIfSMS91P/wzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.120.0':
     resolution: {integrity: sha512-vn21KXLAXzaI3N5CZWlBr1iWeXLl9QFIMor7S1hUjUGTeUuWCoE6JZB040/ZNDwf+JXPX8Ao9KbmJq9FMC2iGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.120.0':
     resolution: {integrity: sha512-SUbUxlar007LTGmSLGIC5x/WJvwhdX+PwNzFJ9f/nOzZOrCFbOT4ikt7pJIRg1tXVsEfzk5mWpGO1NFiSs4PIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.120.0':
     resolution: {integrity: sha512-hYiPJTxyfJY2+lMBFk3p2bo0R9GN+TtpPFlRqVchL1qvLG+pznstramHNvJlw9AjaoRUHwp9IKR7UZQnRPGjgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.120.0':
     resolution: {integrity: sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.120.0':
     resolution: {integrity: sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.120.0':
     resolution: {integrity: sha512-TBU8ZwOUWAOUWVfmI16CYWbvh4uQb9zHnGBHsw5Cp2JUVG044OIY1CSHODLifqzQIMTXvDvLzcL89GGdUIqNrA==}
@@ -1257,48 +1265,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.65.0':
     resolution: {integrity: sha512-IpbA8QGbwFehQhO+YaHwmoI81f93xvywpspf8HrdPCWOIeKwYfM1dhVhO4YKfZewTRRQEPY/JFjTOXTgkwhKrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.65.0':
     resolution: {integrity: sha512-ZSe8HgaZdgyHSv2+/pTG68z10+OarB18CkFKQOhRs3lmmP/p2vuigedK2e9d0ztoG2DU/duJzhxXBSjy/492HQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.65.0':
     resolution: {integrity: sha512-DcTERf++v6HyPHukKAr0JFTRqB+YeDEvqzRgNDMaz7jITPf+tlJIwRxodlAqoXMYhNVEZhXdQM5RAAYH8/oPuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.65.0':
     resolution: {integrity: sha512-xjhMwuFJwRh40NOBzol4gM5gqAa0xPCJU+GQLM6BydV8TbfkIA7JeyCFNhyfbE9Q/5EWcKYTx62R0cRcjP7DAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.65.0':
     resolution: {integrity: sha512-lrWSXb8JzboPWYBG6Kunt/eemvjo2oCFXktShsm3yMToY7HjzKLjxh7CljSvGnnZH9oohNFHOKc9xYpGKCPm6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.65.0':
     resolution: {integrity: sha512-A7xfghw250m4a1sPV+q44Mow2G5bhiC9FBvhAuIhJS6QovWnqzuL5AFQPEuwOB+PM4DhABkqxVa3Iwe3Y/nFlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.65.0':
     resolution: {integrity: sha512-reqOun1+pWO3fW6cv7bsa8hHG0TN3t/82qPdaoJo90FwugXiMjKhZMChmH5Z01cFNRHmxN4+543Fy8478cM/iA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.65.0':
     resolution: {integrity: sha512-KQpqOb/juDBO0xyloDkVDhOVxDUgAfZ2OAAVq99TJScJDzT319xry1QzB9LQohV9QGnA7p6m/XATZkMXc84lwA==}
@@ -1359,36 +1375,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -1516,66 +1538,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -1685,24 +1720,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -3397,24 +3436,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3957,8 +4000,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4122,8 +4165,8 @@ packages:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
-  solid-js@1.9.12:
-    resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
+  solid-js@1.9.13:
+    resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -5509,7 +5552,7 @@ snapshots:
       '@floating-ui/utils': 0.2.11
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      reselect: 5.1.1
+      reselect: 5.2.0
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -6168,39 +6211,39 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.12)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.12)':
+  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.13)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.12)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
-      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.13)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.13)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/rootless@1.5.3(solid-js@1.9.12)':
+  '@solid-primitives/rootless@1.5.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/static-store@0.1.3(solid-js@1.9.12)':
+  '@solid-primitives/static-store@0.1.3(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
-      solid-js: 1.9.12
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.13)
+      solid-js: 1.9.13
 
-  '@solid-primitives/utils@6.4.0(solid-js@1.9.12)':
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.13)':
     dependencies:
-      solid-js: 1.9.12
+      solid-js: 1.9.13
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -6285,12 +6328,12 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
-  '@tanstack/devtools-ui@0.5.2(csstype@3.2.3)(solid-js@1.9.12)':
+  '@tanstack/devtools-ui@0.5.2(csstype@3.2.3)(solid-js@1.9.13)':
     dependencies:
       clsx: 2.1.1
       dayjs: 1.11.20
       goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.12
+      solid-js: 1.9.13
     transitivePeerDependencies:
       - csstype
 
@@ -6310,17 +6353,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@tanstack/devtools@0.12.2(csstype@3.2.3)(solid-js@1.9.12)':
+  '@tanstack/devtools@0.12.2(csstype@3.2.3)(solid-js@1.9.13)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.13)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.13)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.13)
       '@tanstack/devtools-client': 0.0.6
       '@tanstack/devtools-event-bus': 0.4.1
-      '@tanstack/devtools-ui': 0.5.2(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools-ui': 0.5.2(csstype@3.2.3)(solid-js@1.9.13)
       clsx: 2.1.1
       goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.12
+      solid-js: 1.9.13
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -6346,9 +6389,9 @@ snapshots:
 
   '@tanstack/query-devtools@5.100.10': {}
 
-  '@tanstack/react-devtools@0.10.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.12)':
+  '@tanstack/react-devtools@0.10.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)':
     dependencies:
-      '@tanstack/devtools': 0.12.2(csstype@3.2.3)(solid-js@1.9.12)
+      '@tanstack/devtools': 0.12.2(csstype@3.2.3)(solid-js@1.9.13)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       react: 19.2.6
@@ -8590,7 +8633,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  reselect@5.1.1: {}
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -8859,7 +8902,7 @@ snapshots:
 
   smob@1.6.2: {}
 
-  solid-js@1.9.12:
+  solid-js@1.9.13:
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.4

--- a/src/__tests__/frame-timing.test.ts
+++ b/src/__tests__/frame-timing.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest'
 import type { BaseItemDto } from '@/types/jellyfin'
 import { DEFAULT_FRAME_STEP, PLAYER_CONFIG } from '@/lib/constants'
 import { resolveFrameStepSeconds } from '@/lib/frame-rate-utils'
+import { PLAYER_HOTKEYS } from '@/lib/player-shortcuts'
 import {
   formatSkipDurationLabel,
+  getFrameStepTargetTime,
   getSkipStepSeconds,
   isFrameSkipSeconds,
 } from '@/lib/player-timing-utils'
@@ -43,6 +45,31 @@ describe('player timing utilities', () => {
     expect(getSkipStepSeconds(999, frameStep)).toBe(defaultSkip)
   })
 
+  it('computes one-frame seek targets with media bounds', () => {
+    const frameStep = 1001 / 24000
+    const frameAlignedTime = frameStep * 240
+
+    expect(
+      getFrameStepTargetTime(frameAlignedTime, -1, frameStep, 120),
+    ).toBeCloseTo(frameAlignedTime - frameStep, 9)
+    expect(
+      getFrameStepTargetTime(frameAlignedTime, 1, frameStep, 120),
+    ).toBeCloseTo(frameAlignedTime + frameStep, 9)
+    expect(getFrameStepTargetTime(0.01, -1, frameStep, 120)).toBe(0)
+    expect(getFrameStepTargetTime(119.99, 1, frameStep, 120)).toBe(120)
+  })
+
+  it('snaps one-frame seek targets back to frame boundaries', () => {
+    const frameStep = 1001 / 24000
+    const offFrameTime = frameStep * 1.2
+
+    expect(getFrameStepTargetTime(offFrameTime, -1, frameStep, 120)).toBe(0)
+    expect(getFrameStepTargetTime(offFrameTime, 1, frameStep, 120)).toBeCloseTo(
+      frameStep * 2,
+      9,
+    )
+  })
+
   it('formats skip labels consistently', () => {
     expect(isFrameSkipSeconds(0)).toBe(true)
     expect(isFrameSkipSeconds(0.5)).toBe(false)
@@ -68,5 +95,12 @@ describe('player timing utilities', () => {
       DEFAULT_FRAME_STEP,
       9,
     )
+  })
+
+  it('reserves comma and period for frame stepping shortcuts', () => {
+    expect(PLAYER_HOTKEYS.stepFrameBackward).toBe(',')
+    expect(PLAYER_HOTKEYS.stepFrameForward).toBe('.')
+    expect(PLAYER_HOTKEYS.decreaseSpeed).toBe('Alt+,')
+    expect(PLAYER_HOTKEYS.increaseSpeed).toBe('Alt+.')
   })
 })

--- a/src/__tests__/frame-timing.test.ts
+++ b/src/__tests__/frame-timing.test.ts
@@ -62,6 +62,31 @@ describe('player timing utilities', () => {
     expect(getFrameStepTargetTime(119.99, 1, frameStep, 120)).toBe(120)
   })
 
+  it('computes finite seek targets when media duration is unavailable', () => {
+    const frameStep = 1001 / 24000
+    const frameAlignedTime = frameStep * 240
+    const forwardTarget = frameAlignedTime + frameStep
+
+    const targetWithNanDuration = getFrameStepTargetTime(
+      frameAlignedTime,
+      1,
+      frameStep,
+      Number.NaN,
+    )
+
+    expect(Number.isFinite(targetWithNanDuration)).toBe(true)
+    expect(targetWithNanDuration).toBeCloseTo(forwardTarget, 9)
+    expect(
+      getFrameStepTargetTime(
+        frameAlignedTime,
+        1,
+        frameStep,
+        Number.POSITIVE_INFINITY,
+      ),
+    ).toBeCloseTo(forwardTarget, 9)
+    expect(getFrameStepTargetTime(frameAlignedTime, 1, frameStep, -1)).toBe(0)
+  })
+
   it('snaps one-frame seek targets back to frame boundaries', () => {
     const frameStep = 1001 / 24000
     const offFrameTime = frameStep * 1.2
@@ -100,7 +125,7 @@ describe('player timing utilities', () => {
     )
   })
 
-  it('reserves comma and period for frame stepping shortcuts', () => {
+  it('keeps frame stepping and speed shortcuts in sync with the cheatsheet', () => {
     expect(PLAYER_HOTKEYS.stepFrameBackward).toBe(',')
     expect(PLAYER_HOTKEYS.stepFrameForward).toBe('.')
     expect(PLAYER_HOTKEYS.decreaseSpeed).toBe('Alt+,')

--- a/src/__tests__/frame-timing.test.ts
+++ b/src/__tests__/frame-timing.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest'
 import type { BaseItemDto } from '@/types/jellyfin'
 import { DEFAULT_FRAME_STEP, PLAYER_CONFIG } from '@/lib/constants'
 import { resolveFrameStepSeconds } from '@/lib/frame-rate-utils'
-import { PLAYER_HOTKEYS } from '@/lib/player-shortcuts'
+import {
+  PLAYER_HOTKEYS,
+  PLAYER_SHORTCUT_CHEATSHEET,
+} from '@/lib/player-shortcuts'
 import {
   formatSkipDurationLabel,
   getFrameStepTargetTime,
@@ -102,5 +105,22 @@ describe('player timing utilities', () => {
     expect(PLAYER_HOTKEYS.stepFrameForward).toBe('.')
     expect(PLAYER_HOTKEYS.decreaseSpeed).toBe('Alt+,')
     expect(PLAYER_HOTKEYS.increaseSpeed).toBe('Alt+.')
+
+    const stepFrameHotkeys = PLAYER_SHORTCUT_CHEATSHEET.find(
+      (entry) => entry.labelKey === 'shortcuts.stepFrameBackForward',
+    )?.hotkeys
+    const decreaseSpeedHotkeys = PLAYER_SHORTCUT_CHEATSHEET.find(
+      (entry) => entry.labelKey === 'shortcuts.decreaseSpeed',
+    )?.hotkeys
+    const increaseSpeedHotkeys = PLAYER_SHORTCUT_CHEATSHEET.find(
+      (entry) => entry.labelKey === 'shortcuts.increaseSpeed',
+    )?.hotkeys
+
+    expect(stepFrameHotkeys).toEqual([
+      PLAYER_HOTKEYS.stepFrameBackward,
+      PLAYER_HOTKEYS.stepFrameForward,
+    ])
+    expect(decreaseSpeedHotkeys).toEqual([PLAYER_HOTKEYS.decreaseSpeed])
+    expect(increaseSpeedHotkeys).toEqual([PLAYER_HOTKEYS.increaseSpeed])
   })
 })

--- a/src/__tests__/frame-timing.test.ts
+++ b/src/__tests__/frame-timing.test.ts
@@ -125,12 +125,7 @@ describe('player timing utilities', () => {
     )
   })
 
-  it('keeps frame stepping and speed shortcuts in sync with the cheatsheet', () => {
-    expect(PLAYER_HOTKEYS.stepFrameBackward).toBe(',')
-    expect(PLAYER_HOTKEYS.stepFrameForward).toBe('.')
-    expect(PLAYER_HOTKEYS.decreaseSpeed).toBe('Alt+,')
-    expect(PLAYER_HOTKEYS.increaseSpeed).toBe('Alt+.')
-
+  it('cheatsheet step frame and speed hotkeys match PLAYER_HOTKEYS', () => {
     const stepFrameHotkeys = PLAYER_SHORTCUT_CHEATSHEET.find(
       (entry) => entry.labelKey === 'shortcuts.stepFrameBackForward',
     )?.hotkeys

--- a/src/__tests__/properties/trickplay-utils.property.test.ts
+++ b/src/__tests__/properties/trickplay-utils.property.test.ts
@@ -81,6 +81,17 @@ describe('trickplay-utils', () => {
       const result = getBestTrickplayInfo(trickplay)
       expect(result?.info.Width).toBe(240)
     })
+
+    it('ignores non-finite width keys when picking a fallback width', () => {
+      const trickplay: TrickplayData = {
+        'source-1': {
+          '240': { Width: 240, ThumbnailCount: 100, Interval: 10000 },
+          Infinity: { Width: 999, ThumbnailCount: 100, Interval: 10000 },
+        },
+      }
+      const result = getBestTrickplayInfo(trickplay)
+      expect(result?.info.Width).toBe(240)
+    })
   })
 
   describe('getTrickplayPosition', () => {

--- a/src/__tests__/use-player-keyboard.test.ts
+++ b/src/__tests__/use-player-keyboard.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePlayerKeyboard } from '@/hooks/use-player-keyboard'
+import { PLAYER_HOTKEYS } from '@/lib/player-shortcuts'
+
+const { useHotkeyMock } = vi.hoisted(() => ({
+  useHotkeyMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-hotkeys', () => ({
+  useHotkey: useHotkeyMock,
+}))
+
+describe('usePlayerKeyboard', () => {
+  beforeEach(() => {
+    useHotkeyMock.mockReset()
+  })
+
+  it('registers frame-step and playback speed hotkeys from shared shortcut constants', () => {
+    const handler = vi.fn()
+
+    renderHook(() =>
+      usePlayerKeyboard({
+        togglePlay: handler,
+        cycleSkipTimeUp: handler,
+        cycleSkipTimeDown: handler,
+        skipBackward: handler,
+        skipForward: handler,
+        stepFrameBackward: handler,
+        stepFrameForward: handler,
+        pushStartTimestamp: handler,
+        pushEndTimestamp: handler,
+        toggleMute: handler,
+        toggleFullscreen: handler,
+        toggleSubtitles: handler,
+        increaseSpeed: handler,
+        decreaseSpeed: handler,
+      }),
+    )
+
+    expect(useHotkeyMock).toHaveBeenCalledWith(
+      PLAYER_HOTKEYS.stepFrameBackward,
+      handler,
+    )
+    expect(useHotkeyMock).toHaveBeenCalledWith(
+      PLAYER_HOTKEYS.stepFrameForward,
+      handler,
+    )
+    expect(useHotkeyMock).toHaveBeenCalledWith(
+      PLAYER_HOTKEYS.increaseSpeed,
+      handler,
+    )
+    expect(useHotkeyMock).toHaveBeenCalledWith(
+      PLAYER_HOTKEYS.decreaseSpeed,
+      handler,
+    )
+  })
+})

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -54,7 +54,10 @@ import { usePlayerKeyboard } from '@/hooks/use-player-keyboard'
 import { useVibrantButtonStyle } from '@/hooks/use-vibrant-button-style'
 import { showNotification } from '@/lib/notifications'
 import { PLAYER_CONFIG } from '@/lib/constants'
-import { getSkipStepSeconds } from '@/lib/player-timing-utils'
+import {
+  getFrameStepTargetTime,
+  getSkipStepSeconds,
+} from '@/lib/player-timing-utils'
 import { snapToFrame, ticksToSeconds } from '@/lib/time-utils'
 import { extractTracks } from '@/services/video/tracks'
 
@@ -771,44 +774,55 @@ function useRenderPlayer({
   }
 
   const handleSeek = (time: number) => {
-    if (videoRef.current) {
-      clearPlaybackUpdateTimer()
-      videoRef.current.currentTime = time
-      currentTimeRef.current = time
-      lastPlaybackUpdateAtRef.current = performance.now()
-      publishTimelineTime(time)
-    }
+    const video = videoRef.current
+    if (!video) return
+
+    clearPlaybackUpdateTimer()
+    video.currentTime = time
+    currentTimeRef.current = time
+    lastPlaybackUpdateAtRef.current = performance.now()
+    publishTimelineTime(time)
   }
 
   // Skip controls using refs for stable timing
   const skipForward = () => {
-    const video = videoRef.current
-    if (!video) return
-    clearPlaybackUpdateTimer()
     const step = getSkipStepSeconds(skipTimeIndex, frameStep)
     const newTime = Math.min(
       snapToFrame(currentTimeRef.current + step, frameStep),
       durationRef.current,
     )
-    video.currentTime = newTime
-    currentTimeRef.current = newTime
-    lastPlaybackUpdateAtRef.current = performance.now()
-    publishTimelineTime(newTime)
+    handleSeek(newTime)
   }
 
   const skipBackward = () => {
-    const video = videoRef.current
-    if (!video) return
-    clearPlaybackUpdateTimer()
     const step = getSkipStepSeconds(skipTimeIndex, frameStep)
     const newTime = Math.max(
       snapToFrame(currentTimeRef.current - step, frameStep),
       0,
     )
-    video.currentTime = newTime
-    currentTimeRef.current = newTime
-    lastPlaybackUpdateAtRef.current = performance.now()
-    publishTimelineTime(newTime)
+    handleSeek(newTime)
+  }
+
+  const stepFrameForward = () => {
+    handleSeek(
+      getFrameStepTargetTime(
+        currentTimeRef.current,
+        1,
+        frameStep,
+        durationRef.current,
+      ),
+    )
+  }
+
+  const stepFrameBackward = () => {
+    handleSeek(
+      getFrameStepTargetTime(
+        currentTimeRef.current,
+        -1,
+        frameStep,
+        durationRef.current,
+      ),
+    )
   }
 
   const cycleSkipTimeUp = () => {
@@ -909,6 +923,8 @@ function useRenderPlayer({
     cycleSkipTimeDown,
     skipBackward,
     skipForward,
+    stepFrameBackward,
+    stepFrameForward,
     pushStartTimestamp,
     pushEndTimestamp,
     toggleMute,

--- a/src/hooks/use-hls-player.ts
+++ b/src/hooks/use-hls-player.ts
@@ -111,7 +111,12 @@ export function useHlsPlayer({
 
     if (!video || !videoUrl) {
       isActiveRef.current = false
-      return
+      return () => {
+        if (recoveryTimerRef.current) {
+          clearTimeout(recoveryTimerRef.current)
+          recoveryTimerRef.current = null
+        }
+      }
     }
 
     isActiveRef.current = true
@@ -178,6 +183,10 @@ export function useHlsPlayer({
 
     return () => {
       isActiveRef.current = false
+      if (recoveryTimerRef.current) {
+        clearTimeout(recoveryTimerRef.current)
+        recoveryTimerRef.current = null
+      }
       destroyHls()
     }
   }, [videoUrl, destroyHls, clearRecoveryTimer])

--- a/src/hooks/use-hls-player.ts
+++ b/src/hooks/use-hls-player.ts
@@ -109,7 +109,10 @@ export function useHlsPlayer({
   useEffect(() => {
     const video = videoRef.current
 
-    if (!video || !videoUrl) return
+    if (!video || !videoUrl) {
+      isActiveRef.current = false
+      return
+    }
 
     isActiveRef.current = true
 
@@ -175,7 +178,6 @@ export function useHlsPlayer({
 
     return () => {
       isActiveRef.current = false
-      clearRecoveryTimer()
       destroyHls()
     }
   }, [videoUrl, destroyHls, clearRecoveryTimer])

--- a/src/hooks/use-player-keyboard.ts
+++ b/src/hooks/use-player-keyboard.ts
@@ -12,6 +12,8 @@ interface KeyboardHandlers {
   cycleSkipTimeDown: () => void
   skipBackward: () => void
   skipForward: () => void
+  stepFrameBackward: () => void
+  stepFrameForward: () => void
   pushStartTimestamp: () => void
   pushEndTimestamp: () => void
   toggleMute: () => void
@@ -23,8 +25,8 @@ interface KeyboardHandlers {
 
 /**
  * Key mappings:
- * Space=Play, W/S=Skip time, A/D=Skip, E/F=Timestamps,
- * M=Mute, F11=Fullscreen, C=Subtitles, .=Faster, ,=Slower
+ * Space=Play, W/S=Skip time, A/D=Skip, ,/.=Frame step, E/F=Timestamps,
+ * M=Mute, F11=Fullscreen, C=Subtitles, Alt+.=Faster, Alt+,=Slower
  */
 export function usePlayerKeyboard(handlers: KeyboardHandlers): void {
   // Single-key shortcuts: ignoreInputs defaults to true (smart default),
@@ -34,6 +36,8 @@ export function usePlayerKeyboard(handlers: KeyboardHandlers): void {
   useHotkey(PLAYER_HOTKEYS.cycleSkipTimeDown, handlers.cycleSkipTimeDown)
   useHotkey(PLAYER_HOTKEYS.skipBackward, handlers.skipBackward)
   useHotkey(PLAYER_HOTKEYS.skipForward, handlers.skipForward)
+  useHotkey(PLAYER_HOTKEYS.stepFrameBackward, handlers.stepFrameBackward)
+  useHotkey(PLAYER_HOTKEYS.stepFrameForward, handlers.stepFrameForward)
   useHotkey(PLAYER_HOTKEYS.pushStartTimestamp, handlers.pushStartTimestamp)
   useHotkey(PLAYER_HOTKEYS.pushEndTimestamp, handlers.pushEndTimestamp)
   useHotkey(PLAYER_HOTKEYS.toggleMute, handlers.toggleMute)

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -302,7 +302,8 @@
     "prevSegment": "Vorheriges Segment",
     "nextSegment": "Nächstes Segment",
     "increaseSpeed": "Schneller",
-    "decreaseSpeed": "Langsamer"
+    "decreaseSpeed": "Langsamer",
+    "stepFrameBackForward": "Einzelbild zurück / vorwärts"
   },
   "series": {
     "unknownSeries": "Unbekannte Serie",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -302,7 +302,8 @@
     "prevSegment": "Previous segment",
     "nextSegment": "Next segment",
     "increaseSpeed": "Increase speed",
-    "decreaseSpeed": "Decrease speed"
+    "decreaseSpeed": "Decrease speed",
+    "stepFrameBackForward": "Step frame back / forward"
   },
   "series": {
     "unknownSeries": "Unknown Series",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -233,7 +233,8 @@
     "prevSegment": "Segment précédent",
     "nextSegment": "Segment suivant",
     "increaseSpeed": "Accélérer",
-    "decreaseSpeed": "Ralentir"
+    "decreaseSpeed": "Ralentir",
+    "stepFrameBackForward": "Image précédente / suivante"
   },
   "series": {
     "unknownSeries": "Série inconnue",

--- a/src/lib/player-shortcuts.ts
+++ b/src/lib/player-shortcuts.ts
@@ -24,15 +24,33 @@ export const PLAYER_HOTKEYS = {
  *  Includes shortcuts registered in PlayerEditor (Mod+S, [, ]) that
  *  are not part of usePlayerKeyboard. */
 export const PLAYER_SHORTCUT_CHEATSHEET = Object.freeze([
-  // 'Space' is the display-friendly label; actual hotkey uses { key: ' ' }
-  { labelKey: 'shortcuts.playPause', hotkeys: ['Space'] },
-  { labelKey: 'shortcuts.skipBackForward', hotkeys: ['A', 'D'] },
-  { labelKey: 'shortcuts.changeSkipTime', hotkeys: ['W', 'S'] },
-  { labelKey: 'shortcuts.setStartTime', hotkeys: ['E'] },
-  { labelKey: 'shortcuts.setEndTime', hotkeys: ['F'] },
-  { labelKey: 'shortcuts.toggleMute', hotkeys: ['M'] },
-  { labelKey: 'shortcuts.toggleFullscreen', hotkeys: ['F11'] },
-  { labelKey: 'shortcuts.toggleSubtitles', hotkeys: ['C'] },
+  // togglePlay uses { key } shape because useHotkey receives it as a KeyboardEvent.key value
+  { labelKey: 'shortcuts.playPause', hotkeys: [PLAYER_HOTKEYS.togglePlay.key] },
+  {
+    labelKey: 'shortcuts.skipBackForward',
+    hotkeys: [PLAYER_HOTKEYS.skipBackward, PLAYER_HOTKEYS.skipForward],
+  },
+  {
+    labelKey: 'shortcuts.changeSkipTime',
+    hotkeys: [PLAYER_HOTKEYS.cycleSkipTimeUp, PLAYER_HOTKEYS.cycleSkipTimeDown],
+  },
+  {
+    labelKey: 'shortcuts.setStartTime',
+    hotkeys: [PLAYER_HOTKEYS.pushStartTimestamp],
+  },
+  {
+    labelKey: 'shortcuts.setEndTime',
+    hotkeys: [PLAYER_HOTKEYS.pushEndTimestamp],
+  },
+  { labelKey: 'shortcuts.toggleMute', hotkeys: [PLAYER_HOTKEYS.toggleMute] },
+  {
+    labelKey: 'shortcuts.toggleFullscreen',
+    hotkeys: [PLAYER_HOTKEYS.toggleFullscreen],
+  },
+  {
+    labelKey: 'shortcuts.toggleSubtitles',
+    hotkeys: [PLAYER_HOTKEYS.toggleSubtitles],
+  },
   { labelKey: 'shortcuts.saveAll', hotkeys: ['Mod+S'] },
   { labelKey: 'shortcuts.prevSegment', hotkeys: ['['] },
   { labelKey: 'shortcuts.nextSegment', hotkeys: [']'] },

--- a/src/lib/player-shortcuts.ts
+++ b/src/lib/player-shortcuts.ts
@@ -9,13 +9,15 @@ export const PLAYER_HOTKEYS = {
   cycleSkipTimeDown: 'S',
   skipBackward: 'A',
   skipForward: 'D',
+  stepFrameBackward: ',',
+  stepFrameForward: '.',
   pushStartTimestamp: 'E',
   pushEndTimestamp: 'F',
   toggleMute: 'M',
   toggleFullscreen: 'F11',
   toggleSubtitles: 'C',
-  increaseSpeed: '.',
-  decreaseSpeed: ',',
+  increaseSpeed: 'Alt+.',
+  decreaseSpeed: 'Alt+,',
 } as const
 
 /** Display-friendly cheatsheet — a superset of PLAYER_HOTKEYS.
@@ -34,6 +36,7 @@ export const PLAYER_SHORTCUT_CHEATSHEET = Object.freeze([
   { labelKey: 'shortcuts.saveAll', hotkeys: ['Mod+S'] },
   { labelKey: 'shortcuts.prevSegment', hotkeys: ['['] },
   { labelKey: 'shortcuts.nextSegment', hotkeys: [']'] },
-  { labelKey: 'shortcuts.increaseSpeed', hotkeys: ['.'] },
-  { labelKey: 'shortcuts.decreaseSpeed', hotkeys: [','] },
+  { labelKey: 'shortcuts.stepFrameBackForward', hotkeys: [',', '.'] },
+  { labelKey: 'shortcuts.increaseSpeed', hotkeys: ['Alt+.'] },
+  { labelKey: 'shortcuts.decreaseSpeed', hotkeys: ['Alt+,'] },
 ] as const)

--- a/src/lib/player-shortcuts.ts
+++ b/src/lib/player-shortcuts.ts
@@ -36,7 +36,19 @@ export const PLAYER_SHORTCUT_CHEATSHEET = Object.freeze([
   { labelKey: 'shortcuts.saveAll', hotkeys: ['Mod+S'] },
   { labelKey: 'shortcuts.prevSegment', hotkeys: ['['] },
   { labelKey: 'shortcuts.nextSegment', hotkeys: [']'] },
-  { labelKey: 'shortcuts.stepFrameBackForward', hotkeys: [',', '.'] },
-  { labelKey: 'shortcuts.increaseSpeed', hotkeys: ['Alt+.'] },
-  { labelKey: 'shortcuts.decreaseSpeed', hotkeys: ['Alt+,'] },
+  {
+    labelKey: 'shortcuts.stepFrameBackForward',
+    hotkeys: [
+      PLAYER_HOTKEYS.stepFrameBackward,
+      PLAYER_HOTKEYS.stepFrameForward,
+    ],
+  },
+  {
+    labelKey: 'shortcuts.increaseSpeed',
+    hotkeys: [PLAYER_HOTKEYS.increaseSpeed],
+  },
+  {
+    labelKey: 'shortcuts.decreaseSpeed',
+    hotkeys: [PLAYER_HOTKEYS.decreaseSpeed],
+  },
 ] as const)

--- a/src/lib/player-timing-utils.ts
+++ b/src/lib/player-timing-utils.ts
@@ -48,5 +48,7 @@ export function getFrameStepTargetTime(
     currentTime + direction * frameStepSeconds,
     frameStepSeconds,
   )
-  return Math.min(Math.max(nextTime, 0), duration)
+  const maxTime = Number.isFinite(duration) ? Math.max(duration, 0) : Infinity
+
+  return Math.min(Math.max(nextTime, 0), maxTime)
 }

--- a/src/lib/player-timing-utils.ts
+++ b/src/lib/player-timing-utils.ts
@@ -1,4 +1,5 @@
 import { PLAYER_CONFIG } from './constants'
+import { snapToFrame } from './time-utils'
 
 /** Sentinel value in PLAYER_CONFIG.SKIP_TIMES representing "1 frame". */
 const FRAME_SKIP_SENTINEL = 0
@@ -35,4 +36,17 @@ export function getSkipStepSeconds(
 
 export function formatSkipDurationLabel(skipSeconds: number): string {
   return isFrameSkipSeconds(skipSeconds) ? '1f' : `${skipSeconds}s`
+}
+
+export function getFrameStepTargetTime(
+  currentTime: number,
+  direction: -1 | 1,
+  frameStepSeconds: number,
+  duration: number,
+): number {
+  const nextTime = snapToFrame(
+    currentTime + direction * frameStepSeconds,
+    frameStepSeconds,
+  )
+  return Math.min(Math.max(nextTime, 0), duration)
 }

--- a/src/lib/trickplay-utils.ts
+++ b/src/lib/trickplay-utils.ts
@@ -41,10 +41,12 @@ export function getBestTrickplayInfo(
       continue
     }
 
-    const widths = Object.keys(widthMap)
-      .map(Number)
-      .filter((n) => !Number.isNaN(n))
-      .sort((a, b) => a - b)
+    const widths: Array<number> = []
+    for (const key of Object.keys(widthMap)) {
+      const n = Number(key)
+      if (Number.isFinite(n)) widths.push(n)
+    }
+    widths.sort((a, b) => a - b)
 
     if (widths.length === 0) {
       continue


### PR DESCRIPTION
## Summary
- add previous-frame and next-frame player shortcuts using `,` and `.`
- move playback-speed shortcuts to `Alt+,` and `Alt+.` and update the shortcut cheatsheet/locales
- add coverage for frame-step timing and keyboard shortcut registration

## Related
- Closes #120

## Test Plan
- [x] pnpm test
- [x] pnpm lint
- [x] pnpm build
- [x] npx -y react-doctor@latest . --verbose --diff

## Summary by Sourcery

Add frame-by-frame stepping controls to the player and reassign keyboard shortcuts for frame stepping and playback speed control.

New Features:
- Introduce frame-step forward and backward controls in the video player, mapped to dedicated keyboard shortcuts.
- Add a utility to compute bounded, frame-aligned target times for single-frame seeks.

Enhancements:
- Refactor player seek logic to centralize time updates through a shared seek handler.
- Update shared keyboard shortcut constants and the shortcuts cheatsheet/locales to reflect new frame-step and modified speed controls.

Tests:
- Add unit tests for frame-step timing calculations and shortcut assignments.
- Add a hook test to verify that player keyboard hotkeys are registered from shared shortcut constants.