### PR TITLE
Trigger CI on PRs and deploy builds to /review directory

### DIFF
--- a/.github/workflows/build-and-publish-ftps.yml
+++ b/.github/workflows/build-and-publish-ftps.yml
@@ -1,9 +1,14 @@
-name: Build and Publish via FTPS
+name: Build and Publish PR via FTPS
 
 on:
-  push:
+  pull_request:
     branches:
       - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
 
 permissions:
@@ -39,6 +44,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy dist/ via FTPS
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTPS_SERVER }}
@@ -46,3 +52,4 @@ jobs:
           password: ${{ secrets.FTPS_PASSWORD }}
           protocol: ftps
           local-dir: ./dist/
+          server-dir: /review/

--- a/.github/workflows/build-and-publish-ftps.yml
+++ b/.github/workflows/build-and-publish-ftps.yml
@@ -1,6 +1,9 @@
-name: Build and Publish PR via FTPS
+name: Build and Publish via FTPS
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master
@@ -44,7 +47,17 @@ jobs:
         run: pnpm build
 
       - name: Deploy dist/ via FTPS
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request'
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
+        with:
+          server: ${{ secrets.FTPS_SERVER }}
+          username: ${{ secrets.FTPS_USERNAME }}
+          password: ${{ secrets.FTPS_PASSWORD }}
+          protocol: ftps
+          local-dir: ./dist/
+
+      - name: Deploy PR dist/ to /review via FTPS
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTPS_SERVER }}


### PR DESCRIPTION
This PR modifies the FTPS deployment workflow to trigger on pull requests targeting master instead of pushes. Adds deploy protection to prevent forks from accessing FTPS credentials and configures the target directory as /review/ for PR build artifacts.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9e2ae572-99ea-4e87-8940-62ceb1e25923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-022" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9e2ae572-99ea-4e87-8940-62ceb1e25923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-022&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-022"><img alt="INTRO-022" src="https://capy.ai/api/badge/thread.svg?label=INTRO-022"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Update FTPS deployment workflow to run on pull request events targeting master and deploy PR builds to a /review/ directory while protecting credentials from forked repositories.

Deployment:
- Change FTPS workflow trigger from pushes to master to specific pull_request events (opened, synchronize, reopened, ready_for_review) on master.
- Restrict FTPS deployment to non-forked pull requests and configure deployments to target the /review/ directory on the server.