### PR TITLE
Use local Jellyfin type facade

### DIFF
--- a/src/__tests__/connection-wizard.form.test.tsx
+++ b/src/__tests__/connection-wizard.form.test.tsx
@@ -11,9 +11,9 @@ import {
   waitFor,
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
 
 import { ConnectionWizard } from '@/components/connection/ConnectionWizard'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
 import '@/i18n/config'
 
 const discoverServersMock = vi.hoisted(() => vi.fn())

--- a/src/__tests__/properties/best-server-selection.property.test.ts
+++ b/src/__tests__/properties/best-server-selection.property.test.ts
@@ -10,9 +10,9 @@
 
 import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
 import { findBestServer } from '@/services/jellyfin'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Generators

--- a/src/__tests__/properties/discovery-sorting.property.test.ts
+++ b/src/__tests__/properties/discovery-sorting.property.test.ts
@@ -9,9 +9,9 @@
 
 import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
 import { sortServersByScore } from '@/services/jellyfin'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Generators

--- a/src/__tests__/properties/score-display-completeness.property.test.ts
+++ b/src/__tests__/properties/score-display-completeness.property.test.ts
@@ -10,8 +10,8 @@
 
 import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
 import { getScoreDisplay } from '@/services/jellyfin'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants

--- a/src/components/connection/steps/SelectStep.tsx
+++ b/src/components/connection/steps/SelectStep.tsx
@@ -17,7 +17,6 @@ import {
   ShieldAlert,
   ShieldOff,
 } from 'lucide-react'
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -25,7 +24,8 @@ import {
   WizardBackAction,
   WizardContinueAction,
 } from '../WizardActions'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { getScoreDisplay } from '@/services/jellyfin'

--- a/src/components/connection/steps/SuccessStep.tsx
+++ b/src/components/connection/steps/SuccessStep.tsx
@@ -7,9 +7,9 @@
  */
 
 import { CheckCircle } from 'lucide-react'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
 
 import { Button } from '@/components/ui/button'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 
 interface SuccessStepProps {
   selectedServer: RecommendedServerInfo | null

--- a/src/components/connection/use-connection-wizard-controller.ts
+++ b/src/components/connection/use-connection-wizard-controller.ts
@@ -3,9 +3,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm, useStore } from '@tanstack/react-form'
 import { canGoBack, getPreviousStep } from './connection-wizard-flow'
 import type { WizardStep } from './connection-wizard-flow'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
 
 import type { ConnectionWizardFormValues } from '@/lib/forms/connection-form'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 import {
   CONNECTION_WIZARD_DEFAULT_VALUES,
   ConnectionAuthSchema,

--- a/src/components/player/PlayerScrubber.tsx
+++ b/src/components/player/PlayerScrubber.tsx
@@ -8,9 +8,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { ChapterInfo } from '@jellyfin/sdk/lib/generated-client/models'
-
-import type { MediaSegmentDto } from '@/types/jellyfin'
+import type { ChapterInfo, MediaSegmentDto } from '@/types/jellyfin'
 import type { VibrantColors } from '@/hooks/use-vibrant-color'
 import type { TrickplayData, TrickplayPosition } from '@/lib/trickplay-utils'
 import { cn } from '@/lib/utils'

--- a/src/services/items/api.ts
+++ b/src/services/items/api.ts
@@ -10,9 +10,12 @@
  * against Zod schemas to ensure data integrity.
  */
 
-import { ItemFields, SortOrder } from '@jellyfin/sdk/lib/generated-client'
-import type { BaseItemKind } from '@jellyfin/sdk/lib/generated-client'
-import type { BaseItemDto, VirtualFolderInfo } from '@/types/jellyfin'
+import { ItemFields, SortOrder } from '@/types/jellyfin'
+import type {
+  BaseItemDto,
+  BaseItemKind,
+  VirtualFolderInfo,
+} from '@/types/jellyfin'
 import type { ApiOptions } from '@/services/jellyfin'
 import { getRequestConfig, withApi } from '@/services/jellyfin'
 import { AppError, logValidationWarning } from '@/lib/unified-error'

--- a/src/services/jellyfin/discovery.ts
+++ b/src/services/jellyfin/discovery.ts
@@ -4,11 +4,11 @@
  * @module services/jellyfin/discovery
  */
 
-import { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
 import { getJellyfinClient, isAborted } from './core'
 import { normalizeServerAddress } from './security'
-import type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
+import { RecommendedServerInfoScore } from '@/types/jellyfin'
 import type { ApiOptions } from './types'
+import type { RecommendedServerInfo } from '@/types/jellyfin'
 import { AppError, isAbortError } from '@/lib/unified-error'
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -1,15 +1,18 @@
 /**
- * Re-export Jellyfin SDK types for use throughout the application.
- * This provides a single import point for all Jellyfin-related types.
+ * Narrow Jellyfin SDK type/value facade for application imports.
+ *
+ * This contains SDK import paths for boundary hygiene only; it does not
+ * guarantee bundle-size reduction. Keep exports named and minimal.
  */
-export type {
-  BaseItemDto,
-  MediaSegmentDto,
-  TrickplayInfoDto,
-  VirtualFolderInfo,
-} from '@jellyfin/sdk/lib/generated-client'
-export {
-  BaseItemKind,
-  ImageType,
-  MediaSegmentType,
-} from '@jellyfin/sdk/lib/generated-client'
+export type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto'
+export type { ChapterInfo } from '@jellyfin/sdk/lib/generated-client/models/chapter-info'
+export type { MediaSegmentDto } from '@jellyfin/sdk/lib/generated-client/models/media-segment-dto'
+export type { TrickplayInfoDto } from '@jellyfin/sdk/lib/generated-client/models/trickplay-info-dto'
+export type { VirtualFolderInfo } from '@jellyfin/sdk/lib/generated-client/models/virtual-folder-info'
+export { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind'
+export { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type'
+export { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields'
+export { MediaSegmentType } from '@jellyfin/sdk/lib/generated-client/models/media-segment-type'
+export { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order'
+export type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
+export { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'

--- a/src/types/jellyfin.ts
+++ b/src/types/jellyfin.ts
@@ -4,15 +4,20 @@
  * This contains SDK import paths for boundary hygiene only; it does not
  * guarantee bundle-size reduction. Keep exports named and minimal.
  */
+// Discovery
+export type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
+export { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'
+
+// Images
+export { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type'
+
+// Items and media
 export type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models/base-item-dto'
 export type { ChapterInfo } from '@jellyfin/sdk/lib/generated-client/models/chapter-info'
 export type { MediaSegmentDto } from '@jellyfin/sdk/lib/generated-client/models/media-segment-dto'
 export type { TrickplayInfoDto } from '@jellyfin/sdk/lib/generated-client/models/trickplay-info-dto'
 export type { VirtualFolderInfo } from '@jellyfin/sdk/lib/generated-client/models/virtual-folder-info'
 export { BaseItemKind } from '@jellyfin/sdk/lib/generated-client/models/base-item-kind'
-export { ImageType } from '@jellyfin/sdk/lib/generated-client/models/image-type'
 export { ItemFields } from '@jellyfin/sdk/lib/generated-client/models/item-fields'
 export { MediaSegmentType } from '@jellyfin/sdk/lib/generated-client/models/media-segment-type'
 export { SortOrder } from '@jellyfin/sdk/lib/generated-client/models/sort-order'
-export type { RecommendedServerInfo } from '@jellyfin/sdk/lib/models/recommended-server-info'
-export { RecommendedServerInfoScore } from '@jellyfin/sdk/lib/models/recommended-server-info'


### PR DESCRIPTION
## Summary by Sourcery

Use a narrowed local Jellyfin type facade as the single import surface for Jellyfin SDK types across the app.

Enhancements:
- Refine the Jellyfin types module to re-export only specific model-level types and enums from the SDK, including discovery-related types.
- Update components and tests to import Jellyfin types and enums from the local facade instead of directly from the Jellyfin SDK.