### PR TITLE
Add jellyfin fetch helpers and refactor segments

### DIFF
--- a/src/__tests__/jellyfin-http.test.ts
+++ b/src/__tests__/jellyfin-http.test.ts
@@ -79,6 +79,29 @@ describe('jellyfin http helper', () => {
     ).rejects.toMatchObject({ name: 'AbortError' })
   })
 
+  it('rejects invalid endpoints before attaching abort or timeout cleanup work', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const addListener = vi.spyOn(controller.signal, 'addEventListener')
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+
+    await expect(
+      jellyfinFetchEmpty({
+        ...baseOptions,
+        endpoint: '../Users',
+        method: 'DELETE',
+        signal: controller.signal,
+        timeout: 100,
+      }),
+    ).rejects.toMatchObject({ code: ErrorCodes.INVALID_INPUT })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(addListener).not.toHaveBeenCalled()
+    expect(removeListener).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('maps helper-created timeout distinctly from caller abort', async () => {
     vi.useFakeTimers()
     vi.spyOn(globalThis, 'fetch').mockImplementation(

--- a/src/__tests__/jellyfin-http.test.ts
+++ b/src/__tests__/jellyfin-http.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { jellyfinFetchEmpty, jellyfinFetchJson } from '@/services/jellyfin/http'
+import { AppError, ErrorCodes } from '@/lib/unified-error'
+
+const baseOptions = {
+  accessToken: 'secret-token',
+  baseUrl: 'http://localhost:8096',
+  endpoint: 'MediaSegmentsApi/item-id',
+} as const
+
+describe('jellyfin http helper', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('sends authenticated JSON requests without ApiKey query params', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ Id: 'segment-id' }), { status: 200 }),
+      )
+
+    await jellyfinFetchJson({
+      ...baseOptions,
+      body: { Name: 'Intro' },
+      method: 'POST',
+      query: new URLSearchParams({ providerId: 'IntroSkipper' }),
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe(
+      'http://localhost:8096/MediaSegmentsApi/item-id?providerId=IntroSkipper',
+    )
+    expect(String(url)).not.toContain('ApiKey')
+    expect(init?.headers).toMatchObject({
+      Authorization: 'MediaBrowser Token="secret-token"',
+      'Content-Type': 'application/json',
+    })
+    expect(init?.body).toBe(JSON.stringify({ Name: 'Intro' }))
+  })
+
+  it('maps non-2xx responses through AppError status mapping', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 403 }),
+    )
+
+    await expect(
+      jellyfinFetchEmpty({ ...baseOptions, method: 'DELETE' }),
+    ).rejects.toMatchObject({ code: ErrorCodes.FORBIDDEN, status: 403 })
+  })
+
+  it('normalizes network failures through recoverable AppError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed'),
+    )
+
+    await expect(
+      jellyfinFetchEmpty({ ...baseOptions, method: 'DELETE' }),
+    ).rejects.toMatchObject({
+      code: ErrorCodes.NETWORK_ERROR,
+      recoverable: true,
+    })
+  })
+
+  it('preserves caller abort as cancellation', async () => {
+    const controller = new AbortController()
+    controller.abort(new DOMException('Aborted', 'AbortError'))
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new DOMException('Aborted', 'AbortError'),
+    )
+
+    await expect(
+      jellyfinFetchEmpty({
+        ...baseOptions,
+        method: 'DELETE',
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('maps helper-created timeout distinctly from caller abort', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          })
+        }),
+    )
+
+    const request = jellyfinFetchEmpty({
+      ...baseOptions,
+      method: 'DELETE',
+      timeout: 100,
+    })
+    const assertion = expect(request).rejects.toMatchObject({
+      code: ErrorCodes.TIMEOUT,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    await assertion
+  })
+
+  it('parses JSON responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ Id: 'segment-id' }), { status: 200 }),
+    )
+
+    await expect(
+      jellyfinFetchJson<{ Id: string }>({ ...baseOptions, method: 'POST' }),
+    ).resolves.toEqual({ Id: 'segment-id' })
+  })
+
+  it('accepts empty and 204 responses for empty-response calls', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+
+    await expect(
+      jellyfinFetchEmpty({ ...baseOptions, method: 'DELETE' }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects empty bodies when JSON is expected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 200 }),
+    )
+
+    await expect(
+      jellyfinFetchJson({ ...baseOptions, method: 'POST' }),
+    ).rejects.toBeInstanceOf(AppError)
+  })
+
+  it('rejects 204 responses when JSON is expected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+
+    await expect(
+      jellyfinFetchJson({ ...baseOptions, method: 'POST' }),
+    ).rejects.toBeInstanceOf(AppError)
+  })
+
+  it('rejects invalid JSON when JSON is expected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not-json', { status: 200 }),
+    )
+
+    await expect(
+      jellyfinFetchJson({ ...baseOptions, method: 'POST' }),
+    ).rejects.toBeInstanceOf(AppError)
+  })
+})

--- a/src/__tests__/properties/exponential-backoff.property.test.ts
+++ b/src/__tests__/properties/exponential-backoff.property.test.ts
@@ -6,9 +6,10 @@
  * (±25% variation).
  */
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import * as fc from 'fast-check'
-import { calculateBackoffDelay } from '@/lib/retry-utils'
+import { calculateBackoffDelay, withRetry } from '@/lib/retry-utils'
+import { AppError, ErrorCodes } from '@/lib/unified-error'
 
 describe('Exponential Backoff Calculation', () => {
   /**
@@ -238,5 +239,59 @@ describe('Exponential Backoff Calculation', () => {
         expect(delay).toBeLessThanOrEqual(maxExpected)
       }
     }
+  })
+
+  it('retries recoverable AppError statuses from fetch helpers', async () => {
+    const recoverableStatuses = [500, 429]
+
+    await Promise.all(
+      recoverableStatuses.map(async (status) => {
+        const fn = vi
+          .fn<() => Promise<string>>()
+          .mockRejectedValueOnce(AppError.fromStatus(status))
+          .mockResolvedValueOnce('ok')
+
+        await expect(
+          withRetry(fn, { baseDelay: 0, maxDelay: 0, maxRetries: 1 }),
+        ).resolves.toBe('ok')
+        expect(fn).toHaveBeenCalledTimes(2)
+      }),
+    )
+  })
+
+  it('does not retry non-recoverable AppError statuses from fetch helpers', async () => {
+    const nonRecoverableStatuses = [400, 401, 403]
+
+    await Promise.all(
+      nonRecoverableStatuses.map(async (status) => {
+        const error = AppError.fromStatus(status)
+        const fn = vi.fn<() => Promise<string>>().mockRejectedValue(error)
+
+        await expect(
+          withRetry(fn, { baseDelay: 0, maxDelay: 0, maxRetries: 1 }),
+        ).rejects.toBe(error)
+        expect(fn).toHaveBeenCalledTimes(1)
+      }),
+    )
+  })
+
+  it('retries recoverable timeout and network AppErrors from fetch helpers', async () => {
+    const recoverableCodes = [ErrorCodes.TIMEOUT, ErrorCodes.NETWORK_ERROR]
+
+    await Promise.all(
+      recoverableCodes.map(async (code) => {
+        const fn = vi
+          .fn<() => Promise<string>>()
+          .mockRejectedValueOnce(
+            new AppError('Recoverable failure', code, true),
+          )
+          .mockResolvedValueOnce('ok')
+
+        await expect(
+          withRetry(fn, { baseDelay: 0, maxDelay: 0, maxRetries: 1 }),
+        ).resolves.toBe('ok')
+        expect(fn).toHaveBeenCalledTimes(2)
+      }),
+    )
   })
 })

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -11,8 +11,6 @@ import * as fc from 'fast-check'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
-import { AxiosError } from 'axios'
-import type { AxiosRequestConfig } from 'axios'
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import { useDeleteSegment } from '@/hooks/mutations/use-segment-mutations'
 import { segmentsKeys } from '@/hooks/queries/use-segments'
@@ -27,13 +25,7 @@ interface DeleteRequest {
 
 const deleteRequests: Array<DeleteRequest> = []
 
-// Mock axios instance used by SDK
-const mockAxiosInstance = {
-  delete: vi.fn(),
-  get: vi.fn(),
-  post: vi.fn(),
-  defaults: { headers: { common: {} } },
-}
+const jellyfinFetchEmptyMock = vi.hoisted(() => vi.fn())
 
 // Mock APIs object for withApi
 const mockApis = {
@@ -46,8 +38,8 @@ const mockApis = {
   mediaSegmentsApi: {},
   systemApi: {},
   api: {
+    accessToken: 'test-token',
     basePath: 'http://localhost:8096',
-    axiosInstance: mockAxiosInstance,
   },
 }
 
@@ -65,23 +57,15 @@ vi.mock('@/services/jellyfin', () => ({
       timeout: options?.timeout ?? defaultTimeout,
     }),
   ),
-  getAuthenticatedRequestConfig: vi.fn(
-    (
-      accessToken: string | undefined,
-      options?: { signal?: AbortSignal; timeout?: number },
-      defaultTimeout = 30000,
-    ) => ({
-      signal: options?.signal,
-      timeout: options?.timeout ?? defaultTimeout,
-      headers: accessToken
-        ? { Authorization: `MediaBrowser Token="${accessToken}"` }
-        : undefined,
-    }),
-  ),
   isAborted: vi.fn((signal?: AbortSignal) => signal?.aborted === true),
   clearApiCache: vi.fn(),
   getServerBaseUrl: vi.fn(() => 'http://localhost:8096'),
   getAccessToken: vi.fn(() => 'test-token'),
+}))
+
+vi.mock('@/services/jellyfin/http', () => ({
+  jellyfinFetchEmpty: jellyfinFetchEmptyMock,
+  jellyfinFetchJson: vi.fn(),
 }))
 
 // Custom arbitrary for hex strings
@@ -149,55 +133,30 @@ function createWrapper() {
   }
 }
 
-// Setup mock axios to track DELETE requests
-function setupMockAxios(success: boolean = true): void {
-  mockAxiosInstance.delete.mockImplementation(
-    (url: string, _config?: AxiosRequestConfig) => {
-      // Parse URL to extract segment ID and query params
-      const urlObj = new URL(url, 'http://localhost:8096')
-      const pathParts = urlObj.pathname.split('/')
-      // Segment ID is after 'MediaSegmentsApi' in the path
-      const segmentIdPart = pathParts[pathParts.length - 1]
-      // Remove query string from segment ID if present
-      const segmentId = segmentIdPart.split('?')[0]
-
-      // Get query params from URL (segments API puts them in URL)
-      const itemId = urlObj.searchParams.get('itemId') ?? undefined
-      const type = urlObj.searchParams.get('type') ?? undefined
+function setupMockFetch(success: boolean = true): void {
+  jellyfinFetchEmptyMock.mockImplementation(
+    ({ endpoint, query }: { endpoint: string; query?: URLSearchParams }) => {
+      const segmentId = endpoint.split('/').at(-1) ?? ''
+      const itemId = query?.get('itemId') ?? undefined
+      const type = query?.get('type') ?? undefined
 
       deleteRequests.push({
-        url,
+        url: `${endpoint}${query?.toString() ? `?${query.toString()}` : ''}`,
         segmentId,
         itemId,
         type,
       })
 
-      if (success) {
-        return Promise.resolve({
-          data: {},
-          status: 204,
-          statusText: 'No Content',
-        })
-      } else {
-        const error = new AxiosError('Server Error')
-        error.response = {
-          status: 500,
-          data: { message: 'Server Error' },
-          statusText: 'Internal Server Error',
-          headers: {},
-          config: {} as never,
-        }
-        return Promise.reject(error)
-      }
+      return success
+        ? Promise.resolve()
+        : Promise.reject(new Error('Server Error'))
     },
   )
 }
 
 describe('Segment Deletion State Synchronization', () => {
   beforeEach(() => {
-    mockAxiosInstance.delete.mockClear()
-    mockAxiosInstance.get.mockClear()
-    mockAxiosInstance.post.mockClear()
+    jellyfinFetchEmptyMock.mockClear()
     deleteRequests.length = 0
   })
 
@@ -215,10 +174,10 @@ describe('Segment Deletion State Synchronization', () => {
       fc.asyncProperty(segmentArb, async (segment) => {
         // Clear previous requests
         deleteRequests.length = 0
-        mockAxiosInstance.delete.mockClear()
+        jellyfinFetchEmptyMock.mockClear()
 
         // Setup successful delete response
-        setupMockAxios(true)
+        setupMockFetch(true)
 
         const { queryClient, wrapper } = createWrapper()
 
@@ -265,10 +224,10 @@ describe('Segment Deletion State Synchronization', () => {
       fc.asyncProperty(segmentArb, async (segment) => {
         // Clear previous state
         deleteRequests.length = 0
-        mockAxiosInstance.delete.mockClear()
+        jellyfinFetchEmptyMock.mockClear()
 
         // Setup successful delete response
-        setupMockAxios(true)
+        setupMockFetch(true)
 
         const { queryClient, wrapper } = createWrapper()
 
@@ -326,10 +285,10 @@ describe('Segment Deletion State Synchronization', () => {
       fc.asyncProperty(segmentArb, async (segment) => {
         // Clear previous state
         deleteRequests.length = 0
-        mockAxiosInstance.delete.mockClear()
+        jellyfinFetchEmptyMock.mockClear()
 
         // Setup successful delete response
-        setupMockAxios(true)
+        setupMockFetch(true)
 
         const { queryClient, wrapper } = createWrapper()
 
@@ -399,10 +358,10 @@ describe('Segment Deletion State Synchronization', () => {
 
           // Clear previous state
           deleteRequests.length = 0
-          mockAxiosInstance.delete.mockClear()
+          jellyfinFetchEmptyMock.mockClear()
 
           // Setup successful delete response
-          setupMockAxios(true)
+          setupMockFetch(true)
 
           const { queryClient, wrapper } = createWrapper()
 

--- a/src/__tests__/properties/segment-save-reload.property.test.ts
+++ b/src/__tests__/properties/segment-save-reload.property.test.ts
@@ -15,13 +15,8 @@ import type { MediaSegmentDto } from '@/types/jellyfin'
 import { useBatchSaveSegments } from '@/hooks/mutations/use-segment-mutations'
 import { segmentsKeys } from '@/hooks/queries/use-segments'
 
-// Mock axios instance used by SDK
-const mockAxiosInstance = {
-  delete: vi.fn(),
-  get: vi.fn(),
-  post: vi.fn(),
-  defaults: { headers: { common: {} } },
-}
+const jellyfinFetchEmptyMock = vi.hoisted(() => vi.fn())
+const jellyfinFetchJsonMock = vi.hoisted(() => vi.fn())
 
 // Mock APIs object for withApi
 const mockApis = {
@@ -34,8 +29,8 @@ const mockApis = {
   mediaSegmentsApi: {},
   systemApi: {},
   api: {
+    accessToken: 'test-token',
     basePath: 'http://localhost:8096',
-    axiosInstance: mockAxiosInstance,
   },
 }
 
@@ -53,23 +48,15 @@ vi.mock('@/services/jellyfin', () => ({
       timeout: options?.timeout ?? defaultTimeout,
     }),
   ),
-  getAuthenticatedRequestConfig: vi.fn(
-    (
-      accessToken: string | undefined,
-      options?: { signal?: AbortSignal; timeout?: number },
-      defaultTimeout = 30000,
-    ) => ({
-      signal: options?.signal,
-      timeout: options?.timeout ?? defaultTimeout,
-      headers: accessToken
-        ? { Authorization: `MediaBrowser Token="${accessToken}"` }
-        : undefined,
-    }),
-  ),
   isAborted: vi.fn((signal?: AbortSignal) => signal?.aborted === true),
   clearApiCache: vi.fn(),
   getServerBaseUrl: vi.fn(() => 'http://localhost:8096'),
   getAccessToken: vi.fn(() => 'test-token'),
+}))
+
+vi.mock('@/services/jellyfin/http', () => ({
+  jellyfinFetchEmpty: jellyfinFetchEmptyMock,
+  jellyfinFetchJson: jellyfinFetchJsonMock,
 }))
 
 // Custom arbitrary for hex strings
@@ -137,30 +124,20 @@ function createWrapper() {
   }
 }
 
-// Setup mock axios to handle batch save (POST for creates, DELETE for deletes)
-function setupMockAxiosForSave(savedSegments: Array<MediaSegmentDto>): void {
+function setupMockFetchForSave(savedSegments: Array<MediaSegmentDto>): void {
   let callIndex = 0
-  mockAxiosInstance.post.mockImplementation(() => {
+  jellyfinFetchJsonMock.mockImplementation(() => {
     const segment = savedSegments[callIndex % savedSegments.length]
     callIndex++
-    return Promise.resolve({
-      data: segment,
-      status: 200,
-      statusText: 'OK',
-    })
+    return Promise.resolve(segment)
   })
-  mockAxiosInstance.delete.mockResolvedValue({
-    data: {},
-    status: 204,
-    statusText: 'No Content',
-  })
+  jellyfinFetchEmptyMock.mockResolvedValue(undefined)
 }
 
 describe('Segment Save Reload', () => {
   beforeEach(() => {
-    mockAxiosInstance.delete.mockClear()
-    mockAxiosInstance.get.mockClear()
-    mockAxiosInstance.post.mockClear()
+    jellyfinFetchEmptyMock.mockClear()
+    jellyfinFetchJsonMock.mockClear()
   })
 
   afterEach(() => {
@@ -186,11 +163,11 @@ describe('Segment Save Reload', () => {
             return fc.constant(withSameItemId)
           }),
         async (segments) => {
-          mockAxiosInstance.post.mockClear()
-          mockAxiosInstance.delete.mockClear()
+          jellyfinFetchJsonMock.mockClear()
+          jellyfinFetchEmptyMock.mockClear()
 
           const itemId = segments[0].ItemId
-          setupMockAxiosForSave(segments)
+          setupMockFetchForSave(segments)
 
           const { queryClient, wrapper } = createWrapper()
 

--- a/src/__tests__/properties/wizard-error-handling.property.test.ts
+++ b/src/__tests__/properties/wizard-error-handling.property.test.ts
@@ -174,10 +174,10 @@ describe('Wizard Schema Validation', () => {
 })
 
 describe('Error Code Mapping', () => {
-  it('maps 401 status to UNAUTHORIZED code', () => {
+  it('maps 401 status to non-recoverable UNAUTHORIZED code', () => {
     const error = AppError.fromStatus(401)
     expect(error.code).toBe(ErrorCodes.UNAUTHORIZED)
-    expect(error.recoverable).toBe(true)
+    expect(error.recoverable).toBe(false)
   })
 
   it('maps 403 status to FORBIDDEN code', () => {

--- a/src/lib/unified-error.ts
+++ b/src/lib/unified-error.ts
@@ -65,7 +65,8 @@ const getProp = <T>(e: unknown, key: string): T | undefined =>
 
 const getCode = (e: unknown) => getProp<string>(e, 'code')
 const getStatus = (e: unknown) =>
-  getProp<{ status?: number }>(e, 'response')?.status
+  getProp<{ status?: number }>(e, 'response')?.status ??
+  getProp<number>(e, 'status')
 
 export const isAbortError = (e: unknown): boolean =>
   (e instanceof DOMException && e.name === 'AbortError') ||
@@ -80,9 +81,18 @@ const isNetworkError = (e: unknown): boolean => {
 
 export const isRecoverableError = (e: unknown): boolean => {
   if (isAbortError(e)) return false
-  if (isTimeoutError(e) || isNetworkError(e)) return true
+
   const status = getStatus(e)
-  return status !== undefined && (status >= 500 || status === 429)
+  if (status !== undefined) return status >= 500 || status === 429
+
+  const code = getCode(e)
+  if (code === ErrorCodes.TIMEOUT || code === ErrorCodes.NETWORK_ERROR) {
+    return true
+  }
+
+  if (isTimeoutError(e) || isNetworkError(e)) return true
+
+  return e instanceof AppError && e.recoverable === true
 }
 
 // HTTP status mapping
@@ -93,7 +103,7 @@ const STATUS_MAP: Record<
   401: {
     code: ErrorCodes.UNAUTHORIZED,
     message: 'Authentication required',
-    recoverable: true,
+    recoverable: false,
   },
   403: {
     code: ErrorCodes.FORBIDDEN,

--- a/src/services/jellyfin/core.ts
+++ b/src/services/jellyfin/core.ts
@@ -245,33 +245,6 @@ export function getRequestConfig(
   }
 }
 
-/**
- * Gets request config with authentication headers for direct axios calls.
- * Use this when making calls with apis.api.axiosInstance directly.
- */
-export function getAuthenticatedRequestConfig(
-  accessToken: string | undefined,
-  options?: ApiOptions,
-  defaultTimeout: number = API_CONFIG.DEFAULT_TIMEOUT_MS,
-): { signal?: AbortSignal; timeout: number; headers?: Record<string, string> } {
-  const config: {
-    signal?: AbortSignal
-    timeout: number
-    headers?: Record<string, string>
-  } = {
-    signal: options?.signal,
-    timeout: options?.timeout ?? defaultTimeout,
-  }
-
-  if (accessToken) {
-    config.headers = {
-      Authorization: `MediaBrowser Token="${accessToken}"`,
-    }
-  }
-
-  return config
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Unified API Wrapper
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/services/jellyfin/http.ts
+++ b/src/services/jellyfin/http.ts
@@ -1,4 +1,5 @@
 import { AppError, ErrorCodes, isAbortError } from '@/lib/unified-error'
+import { isValidEndpoint } from './security'
 
 export interface JellyfinFetchOptions {
   baseUrl: string
@@ -83,6 +84,11 @@ async function readJson<T>(response: Response): Promise<T> {
 
 async function jellyfinRequest<T>(options: RequestOptions): Promise<T> {
   const { accessToken, body, expectJson, method, signal, timeout } = options
+
+  if (!isValidEndpoint(options.endpoint)) {
+    throw new AppError('Invalid endpoint', ErrorCodes.INVALID_INPUT, false)
+  }
+
   const requestSignal = createRequestSignal(signal, timeout)
 
   try {

--- a/src/services/jellyfin/http.ts
+++ b/src/services/jellyfin/http.ts
@@ -1,0 +1,145 @@
+import { AppError, ErrorCodes, isAbortError } from '@/lib/unified-error'
+
+export interface JellyfinFetchOptions {
+  baseUrl: string
+  accessToken?: string
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  endpoint: string
+  query?: URLSearchParams
+  body?: unknown
+  signal?: AbortSignal
+  timeout?: number
+}
+
+interface RequestOptions extends JellyfinFetchOptions {
+  expectJson: boolean
+}
+
+const trimSlashes = (value: string): string => value.replace(/^\/+|\/+$/g, '')
+
+function buildUrl(baseUrl: string, endpoint: string, query?: URLSearchParams) {
+  const base = baseUrl.replace(/\/+$/, '')
+  const path = trimSlashes(endpoint)
+  const qs = query?.toString()
+  return `${base}/${path}${qs ? `?${qs}` : ''}`
+}
+
+function createRequestSignal(
+  callerSignal: AbortSignal | undefined,
+  timeout: number | undefined,
+): { signal?: AbortSignal; cleanup: () => void; didTimeout: () => boolean } {
+  if (!callerSignal && timeout == null) {
+    return { cleanup: () => {}, didTimeout: () => false }
+  }
+
+  const controller = new AbortController()
+  let timedOut = false
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  const abortFromCaller = () => {
+    controller.abort(
+      callerSignal?.reason ?? new DOMException('Aborted', 'AbortError'),
+    )
+  }
+
+  if (callerSignal?.aborted) abortFromCaller()
+  else callerSignal?.addEventListener('abort', abortFromCaller, { once: true })
+
+  if (timeout != null) {
+    timeoutId = setTimeout(() => {
+      timedOut = true
+      controller.abort(new DOMException('Timeout', 'TimeoutError'))
+    }, timeout)
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timeoutId) clearTimeout(timeoutId)
+      callerSignal?.removeEventListener('abort', abortFromCaller)
+    },
+    didTimeout: () => timedOut,
+  }
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const text = await response.text()
+  if (!text) {
+    throw new AppError('Expected JSON response', ErrorCodes.UNKNOWN, false)
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch (error) {
+    throw new AppError(
+      'Failed to parse JSON response',
+      ErrorCodes.UNKNOWN,
+      false,
+      undefined,
+      error,
+    )
+  }
+}
+
+async function jellyfinRequest<T>(options: RequestOptions): Promise<T> {
+  const { accessToken, body, expectJson, method, signal, timeout } = options
+  const requestSignal = createRequestSignal(signal, timeout)
+
+  try {
+    const headers: Record<string, string> = {}
+    if (accessToken)
+      headers.Authorization = `MediaBrowser Token="${accessToken}"`
+    if (body !== undefined) headers['Content-Type'] = 'application/json'
+
+    const response = await fetch(
+      buildUrl(options.baseUrl, options.endpoint, options.query),
+      {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers,
+        method,
+        signal: requestSignal.signal,
+      },
+    )
+
+    if (!response.ok) throw AppError.fromStatus(response.status)
+    if (!expectJson) return undefined as T
+
+    return await readJson<T>(response)
+  } catch (error) {
+    if (requestSignal.didTimeout()) {
+      throw new AppError(
+        'Request timed out',
+        ErrorCodes.TIMEOUT,
+        true,
+        undefined,
+        error,
+      )
+    }
+    if (isAbortError(error)) throw error
+    if (error instanceof AppError) throw error
+    if (error instanceof TypeError) {
+      throw new AppError(
+        'Network connection failed',
+        ErrorCodes.NETWORK_ERROR,
+        true,
+        undefined,
+        error,
+      )
+    }
+    throw AppError.from(error)
+  } finally {
+    requestSignal.cleanup()
+  }
+}
+
+export function jellyfinFetchJson<T>(
+  options: JellyfinFetchOptions,
+): Promise<T> {
+  return jellyfinRequest<T>({ ...options, expectJson: true })
+}
+
+export function jellyfinFetchEmpty(
+  options: JellyfinFetchOptions,
+): Promise<void> {
+  return jellyfinRequest<void>({ ...options, expectJson: false })
+}

--- a/src/services/jellyfin/index.ts
+++ b/src/services/jellyfin/index.ts
@@ -46,7 +46,6 @@ export type { ApiOptions, AuthCredentials, AuthResult } from './types'
 export {
   withApi,
   getRequestConfig,
-  getAuthenticatedRequestConfig,
   isPluginMode,
   getPluginCredentials,
   getDeviceId,

--- a/src/services/jellyfin/security.ts
+++ b/src/services/jellyfin/security.ts
@@ -109,7 +109,7 @@ export function normalizeServerAddress(address: string): string {
 }
 
 /** Validates an endpoint path for traversal attacks. */
-function isValidEndpoint(endpoint: string): boolean {
+export function isValidEndpoint(endpoint: string): boolean {
   return !PATH_TRAVERSAL.test(endpoint) && !ENCODED_TRAVERSAL.test(endpoint)
 }
 

--- a/src/services/segments/api.ts
+++ b/src/services/segments/api.ts
@@ -13,12 +13,8 @@
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import type { RetryOptions } from '@/lib/retry-utils'
 import type { ApiOptions } from '@/services/jellyfin'
-import {
-  getAuthenticatedRequestConfig,
-  getRequestConfig,
-  getServerBaseUrl,
-  withApi,
-} from '@/services/jellyfin'
+import { getRequestConfig, withApi } from '@/services/jellyfin'
+import { jellyfinFetchEmpty, jellyfinFetchJson } from '@/services/jellyfin/http'
 import { secondsToTicks, ticksToSeconds } from '@/lib/time-utils'
 import { generateUUID } from '@/lib/segment-utils'
 import { API_CONFIG } from '@/lib/constants'
@@ -90,12 +86,9 @@ const validateForDelete = (segment: MediaSegmentDto): boolean => {
 // API Operations (Using withApi Pattern Consistently)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Builds segment API URL with proper encoding */
-const buildSegmentUrl = (path: string, params?: URLSearchParams): string => {
-  const base = getServerBaseUrl()
-  const qs = params?.toString()
-  return `${base}/MediaSegmentsApi/${path}${qs ? `?${qs}` : ''}`
-}
+/** Builds segment API endpoint path with proper encoding */
+const buildSegmentEndpoint = (path: string): string =>
+  `MediaSegmentsApi/${path}`
 
 /** Executes segment mutation with retry logic */
 const withSegmentRetry = <T>(
@@ -134,21 +127,22 @@ async function createSegment(
   if (!validateForCreate(segment)) return false
 
   const result = await withApi(async (apis) => {
-    const url = buildSegmentUrl(
-      encodeUrlParam(segment.ItemId!),
-      new URLSearchParams({ providerId: DEFAULT_SEGMENT_PROVIDER_ID }),
-    )
+    const endpoint = buildSegmentEndpoint(encodeUrlParam(segment.ItemId!))
+    const query = new URLSearchParams({
+      providerId: DEFAULT_SEGMENT_PROVIDER_ID,
+    })
 
     return withSegmentRetry(async () => {
-      const { data } = await apis.api.axiosInstance.post<MediaSegmentDto>(
-        url,
-        toServerSegment(segment),
-        getAuthenticatedRequestConfig(
-          apis.api.accessToken,
-          options,
-          API_CONFIG.SEGMENT_TIMEOUT_MS,
-        ),
-      )
+      const data = await jellyfinFetchJson<MediaSegmentDto>({
+        accessToken: apis.api.accessToken,
+        baseUrl: apis.api.basePath,
+        body: toServerSegment(segment),
+        endpoint,
+        method: 'POST',
+        query,
+        signal: options?.signal,
+        timeout: options?.timeout ?? API_CONFIG.SEGMENT_TIMEOUT_MS,
+      })
       return toUiSegment(data)
     }, options)
   }, options)
@@ -175,17 +169,18 @@ export async function deleteSegment(
       params.set('type', String(segment.Type))
     }
 
-    const url = buildSegmentUrl(encodeUrlParam(segment.Id!), params)
+    const endpoint = buildSegmentEndpoint(encodeUrlParam(segment.Id!))
 
     return withSegmentRetry(async () => {
-      await apis.api.axiosInstance.delete(
-        url,
-        getAuthenticatedRequestConfig(
-          apis.api.accessToken,
-          options,
-          API_CONFIG.SEGMENT_TIMEOUT_MS,
-        ),
-      )
+      await jellyfinFetchEmpty({
+        accessToken: apis.api.accessToken,
+        baseUrl: apis.api.basePath,
+        endpoint,
+        method: 'DELETE',
+        query: params,
+        signal: options?.signal,
+        timeout: options?.timeout ?? API_CONFIG.SEGMENT_TIMEOUT_MS,
+      })
       return true
     }, options)
   }, options)


### PR DESCRIPTION
## Summary by Sourcery

Replace direct axios usage with centralized Jellyfin fetch helpers for segment APIs and tighten unified error handling and retry behavior.

New Features:
- Introduce jellyfin HTTP helper utilities for authenticated JSON and empty-body requests with timeout and error normalization.

Bug Fixes:
- Ensure 401 UNAUTHORIZED errors are treated as non-recoverable in error handling.
- Fix recoverability detection to correctly handle status-based, code-based, and AppError-based failures from fetch helpers.

Enhancements:
- Refactor segment create/delete API calls to use the new Jellyfin fetch helpers instead of direct axios access.
- Improve retry logic to interoperate correctly with AppError instances produced by the new HTTP helpers.
- Remove now-unused authenticated axios request configuration helper in favor of the new fetch-based flow.

Tests:
- Add dedicated tests for the Jellyfin HTTP helpers covering auth headers, URL construction, timeout, network errors, and JSON parsing behavior.
- Update property-based tests for segment deletion and save/reload flows to use the new fetch helpers.
- Extend exponential backoff property tests to cover recoverable and non-recoverable AppErrors emitted by fetch helpers.
- Adjust wizard error-handling tests to reflect updated UNAUTHORIZED recoverability semantics.