### PR TITLE
Improve delete-segment rollback and tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,5 @@
   "files.readonlyInclude": {
     "**/routeTree.gen.ts": true
   },
-  "i18n-ally.localesPaths": [
-    "src/i18n",
-    "src/i18n/locales"
-  ]
+  "i18n-ally.localesPaths": ["src/i18n", "src/i18n/locales"]
 }

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -12,7 +12,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import type { MediaSegmentDto } from '@/types/jellyfin'
-import { useDeleteSegment } from '@/services/segments/mutations'
+import {
+  DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
+  useDeleteSegment,
+} from '@/services/segments/mutations'
 import { segmentsKeys } from '@/services/segments/query-keys'
 
 // Track DELETE requests for verification
@@ -154,6 +157,17 @@ function setupMockFetch(success: boolean = true): void {
   )
 }
 
+const createSegmentDto = (
+  overrides: Partial<MediaSegmentDto> = {},
+): MediaSegmentDto => ({
+  Id: '00000000-0000-4000-8000-000000000001',
+  ItemId: '00000000-0000-4000-8000-000000000002',
+  Type: 'Intro',
+  StartTicks: 100,
+  EndTicks: 200,
+  ...overrides,
+})
+
 describe('Segment Deletion State Synchronization', () => {
   beforeEach(() => {
     jellyfinFetchEmptyMock.mockClear()
@@ -276,19 +290,12 @@ describe('Segment Deletion State Synchronization', () => {
   })
 
   it('restores previous cache and invalidates when optimistic delete changes cache length', async () => {
-    const segment: MediaSegmentDto = {
-      Id: '00000000-0000-4000-8000-000000000001',
-      ItemId: '00000000-0000-4000-8000-000000000002',
-      Type: 'Intro',
-      StartTicks: 100,
-      EndTicks: 200,
-    }
-    const otherSegment: MediaSegmentDto = {
-      ...segment,
+    const segment = createSegmentDto()
+    const otherSegment = createSegmentDto({
       Id: '00000000-0000-4000-8000-000000000003',
       StartTicks: 300,
       EndTicks: 400,
-    }
+    })
 
     setupMockFetch(false)
 
@@ -304,7 +311,7 @@ describe('Segment Deletion State Synchronization', () => {
     const { result } = renderHook(() => useDeleteSegment(), { wrapper })
 
     await expect(result.current.mutateAsync(segment)).rejects.toThrow(
-      'The server did not confirm the delete. Please try again.',
+      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
     )
 
     expect(
@@ -319,25 +326,17 @@ describe('Segment Deletion State Synchronization', () => {
   })
 
   it('restores previous cache without invalidation when optimistic delete does not change cache length', async () => {
-    const segment: MediaSegmentDto = {
-      Id: '00000000-0000-4000-8000-000000000001',
-      ItemId: '00000000-0000-4000-8000-000000000002',
-      Type: 'Intro',
-      StartTicks: 100,
-      EndTicks: 200,
-    }
-    const otherSegment: MediaSegmentDto = {
-      ...segment,
+    const segment = createSegmentDto()
+    const otherSegment = createSegmentDto({
       Id: '00000000-0000-4000-8000-000000000003',
       StartTicks: 300,
       EndTicks: 400,
-    }
-    const anotherSegment: MediaSegmentDto = {
-      ...segment,
+    })
+    const anotherSegment = createSegmentDto({
       Id: '00000000-0000-4000-8000-000000000004',
       StartTicks: 500,
       EndTicks: 600,
-    }
+    })
 
     setupMockFetch(false)
 
@@ -355,7 +354,7 @@ describe('Segment Deletion State Synchronization', () => {
     const { result } = renderHook(() => useDeleteSegment(), { wrapper })
 
     await expect(result.current.mutateAsync(segment)).rejects.toThrow(
-      'The server did not confirm the delete. Please try again.',
+      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
     )
 
     const restored = queryClient.getQueryData<Array<MediaSegmentDto>>(

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -13,10 +13,12 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import {
+  DELETE_SEGMENT_INVALID_MESSAGE,
   DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
   useDeleteSegment,
 } from '@/services/segments/mutations'
 import { segmentsKeys } from '@/services/segments/query-keys'
+import { ErrorCodes } from '@/lib/unified-error'
 
 // Track DELETE requests for verification
 interface DeleteRequest {
@@ -29,6 +31,8 @@ interface DeleteRequest {
 const deleteRequests: Array<DeleteRequest> = []
 
 const jellyfinFetchEmptyMock = vi.hoisted(() => vi.fn())
+const showErrorMock = vi.hoisted(() => vi.fn())
+const showSuccessMock = vi.hoisted(() => vi.fn())
 
 // Mock APIs object for withApi
 const mockApis = {
@@ -69,6 +73,11 @@ vi.mock('@/services/jellyfin', () => ({
 vi.mock('@/services/jellyfin/http', () => ({
   jellyfinFetchEmpty: jellyfinFetchEmptyMock,
   jellyfinFetchJson: vi.fn(),
+}))
+
+vi.mock('@/lib/notifications', () => ({
+  showError: showErrorMock,
+  showSuccess: showSuccessMock,
 }))
 
 // Custom arbitrary for hex strings
@@ -157,6 +166,28 @@ function setupMockFetch(success: boolean = true): void {
   )
 }
 
+function setupAbortThenSuccessFetch(): void {
+  let callCount = 0
+  jellyfinFetchEmptyMock.mockImplementation(
+    ({ signal }: { signal?: AbortSignal }) => {
+      callCount += 1
+      if (callCount > 1) return Promise.resolve()
+
+      return new Promise<void>((_, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+        signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+    },
+  )
+}
+
 const createSegmentDto = (
   overrides: Partial<MediaSegmentDto> = {},
 ): MediaSegmentDto => ({
@@ -171,6 +202,8 @@ const createSegmentDto = (
 describe('Segment Deletion State Synchronization', () => {
   beforeEach(() => {
     jellyfinFetchEmptyMock.mockClear()
+    showErrorMock.mockClear()
+    showSuccessMock.mockClear()
     deleteRequests.length = 0
   })
 
@@ -365,6 +398,62 @@ describe('Segment Deletion State Synchronization', () => {
       previousSegments.map((s) => s.Id),
     )
     expect(invalidateQueriesSpy).not.toHaveBeenCalled()
+  })
+
+  it('suppresses error notification when delete is cancelled by a newer mutation', async () => {
+    const segment = createSegmentDto()
+    const otherSegment = createSegmentDto({
+      Id: '00000000-0000-4000-8000-000000000003',
+      StartTicks: 300,
+      EndTicks: 400,
+    })
+
+    setupAbortThenSuccessFetch()
+
+    const { queryClient, wrapper } = createWrapper()
+    queryClient.setQueryData<Array<MediaSegmentDto>>(
+      segmentsKeys.list(segment.ItemId!),
+      [segment, otherSegment],
+    )
+
+    const { result } = renderHook(() => useDeleteSegment(), { wrapper })
+
+    const cancelledDelete = result.current.mutateAsync(segment)
+    await waitFor(() => expect(jellyfinFetchEmptyMock).toHaveBeenCalledTimes(1))
+
+    const confirmedDelete = result.current.mutateAsync(otherSegment)
+
+    await expect(cancelledDelete).rejects.toMatchObject({
+      code: ErrorCodes.CANCELLED,
+    })
+    await expect(confirmedDelete).resolves.toBe(true)
+    expect(showErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('reports invalid segment IDs without using server confirmation message', async () => {
+    const segment = createSegmentDto({ Id: 'not-a-valid-id' })
+
+    const { queryClient, wrapper } = createWrapper()
+    queryClient.setQueryData<Array<MediaSegmentDto>>(
+      segmentsKeys.list(segment.ItemId!),
+      [segment],
+    )
+
+    const { result } = renderHook(() => useDeleteSegment(), { wrapper })
+
+    await expect(result.current.mutateAsync(segment)).rejects.toMatchObject({
+      code: ErrorCodes.INVALID_INPUT,
+      message: DELETE_SEGMENT_INVALID_MESSAGE,
+    })
+    expect(jellyfinFetchEmptyMock).not.toHaveBeenCalled()
+    expect(showErrorMock).toHaveBeenCalledWith(
+      'Delete segment failed',
+      DELETE_SEGMENT_INVALID_MESSAGE,
+    )
+    expect(showErrorMock).not.toHaveBeenCalledWith(
+      'Delete segment failed',
+      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
+    )
   })
 
   /**

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -12,11 +12,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import type { MediaSegmentDto } from '@/types/jellyfin'
-import {
-  DELETE_SEGMENT_INVALID_MESSAGE,
-  DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
-  useDeleteSegment,
-} from '@/services/segments/mutations'
+import { useDeleteSegment } from '@/services/segments/mutations'
 import { segmentsKeys } from '@/services/segments/query-keys'
 import { ErrorCodes } from '@/lib/unified-error'
 
@@ -32,7 +28,6 @@ const deleteRequests: Array<DeleteRequest> = []
 
 const jellyfinFetchEmptyMock = vi.hoisted(() => vi.fn())
 const showErrorMock = vi.hoisted(() => vi.fn())
-const showSuccessMock = vi.hoisted(() => vi.fn())
 
 // Mock APIs object for withApi
 const mockApis = {
@@ -77,7 +72,7 @@ vi.mock('@/services/jellyfin/http', () => ({
 
 vi.mock('@/lib/notifications', () => ({
   showError: showErrorMock,
-  showSuccess: showSuccessMock,
+  showSuccess: vi.fn(),
 }))
 
 // Custom arbitrary for hex strings
@@ -203,7 +198,6 @@ describe('Segment Deletion State Synchronization', () => {
   beforeEach(() => {
     jellyfinFetchEmptyMock.mockClear()
     showErrorMock.mockClear()
-    showSuccessMock.mockClear()
     deleteRequests.length = 0
   })
 
@@ -344,7 +338,7 @@ describe('Segment Deletion State Synchronization', () => {
     const { result } = renderHook(() => useDeleteSegment(), { wrapper })
 
     await expect(result.current.mutateAsync(segment)).rejects.toThrow(
-      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
+      'The server did not confirm the delete. Please try again.',
     )
 
     expect(
@@ -387,7 +381,7 @@ describe('Segment Deletion State Synchronization', () => {
     const { result } = renderHook(() => useDeleteSegment(), { wrapper })
 
     await expect(result.current.mutateAsync(segment)).rejects.toThrow(
-      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
+      'The server did not confirm the delete. Please try again.',
     )
 
     const restored = queryClient.getQueryData<Array<MediaSegmentDto>>(
@@ -443,16 +437,16 @@ describe('Segment Deletion State Synchronization', () => {
 
     await expect(result.current.mutateAsync(segment)).rejects.toMatchObject({
       code: ErrorCodes.INVALID_INPUT,
-      message: DELETE_SEGMENT_INVALID_MESSAGE,
+      message: 'Invalid or missing segment ID',
     })
     expect(jellyfinFetchEmptyMock).not.toHaveBeenCalled()
     expect(showErrorMock).toHaveBeenCalledWith(
       'Delete segment failed',
-      DELETE_SEGMENT_INVALID_MESSAGE,
+      'Invalid or missing segment ID',
     )
     expect(showErrorMock).not.toHaveBeenCalledWith(
       'Delete segment failed',
-      DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE,
+      'The server did not confirm the delete. Please try again.',
     )
   })
 

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -318,6 +318,56 @@ describe('Segment Deletion State Synchronization', () => {
     })
   })
 
+  it('restores previous cache without invalidation when optimistic delete does not change cache length', async () => {
+    const segment: MediaSegmentDto = {
+      Id: '00000000-0000-4000-8000-000000000001',
+      ItemId: '00000000-0000-4000-8000-000000000002',
+      Type: 'Intro',
+      StartTicks: 100,
+      EndTicks: 200,
+    }
+    const otherSegment: MediaSegmentDto = {
+      ...segment,
+      Id: '00000000-0000-4000-8000-000000000003',
+      StartTicks: 300,
+      EndTicks: 400,
+    }
+    const anotherSegment: MediaSegmentDto = {
+      ...segment,
+      Id: '00000000-0000-4000-8000-000000000004',
+      StartTicks: 500,
+      EndTicks: 600,
+    }
+
+    setupMockFetch(false)
+
+    const { queryClient, wrapper } = createWrapper()
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    // The deleted segment is not in the cache, so the optimistic filter leaves
+    // the cache length and IDs unchanged before rollback.
+    const previousSegments = [otherSegment, anotherSegment]
+
+    queryClient.setQueryData<Array<MediaSegmentDto>>(
+      segmentsKeys.list(segment.ItemId!),
+      previousSegments,
+    )
+
+    const { result } = renderHook(() => useDeleteSegment(), { wrapper })
+
+    await expect(result.current.mutateAsync(segment)).rejects.toThrow(
+      'The server did not confirm the delete. Please try again.',
+    )
+
+    const restored = queryClient.getQueryData<Array<MediaSegmentDto>>(
+      segmentsKeys.list(segment.ItemId!),
+    )
+    expect(restored).toEqual(previousSegments)
+    expect(restored?.map((s) => s.Id)).toEqual(
+      previousSegments.map((s) => s.Id),
+    )
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled()
+  })
+
   /**
    * Property: DELETE request includes correct query parameters
    * For any valid segment, the DELETE request SHALL include

--- a/src/__tests__/properties/segment-deletion.property.test.ts
+++ b/src/__tests__/properties/segment-deletion.property.test.ts
@@ -275,6 +275,49 @@ describe('Segment Deletion State Synchronization', () => {
     )
   })
 
+  it('restores previous cache and invalidates when optimistic delete changes cache length', async () => {
+    const segment: MediaSegmentDto = {
+      Id: '00000000-0000-4000-8000-000000000001',
+      ItemId: '00000000-0000-4000-8000-000000000002',
+      Type: 'Intro',
+      StartTicks: 100,
+      EndTicks: 200,
+    }
+    const otherSegment: MediaSegmentDto = {
+      ...segment,
+      Id: '00000000-0000-4000-8000-000000000003',
+      StartTicks: 300,
+      EndTicks: 400,
+    }
+
+    setupMockFetch(false)
+
+    const { queryClient, wrapper } = createWrapper()
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const previousSegments = [segment, otherSegment]
+
+    queryClient.setQueryData<Array<MediaSegmentDto>>(
+      segmentsKeys.list(segment.ItemId!),
+      previousSegments,
+    )
+
+    const { result } = renderHook(() => useDeleteSegment(), { wrapper })
+
+    await expect(result.current.mutateAsync(segment)).rejects.toThrow(
+      'The server did not confirm the delete. Please try again.',
+    )
+
+    expect(
+      queryClient.getQueryData<Array<MediaSegmentDto>>(
+        segmentsKeys.list(segment.ItemId!),
+      ),
+    ).toEqual(previousSegments)
+    expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1)
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: segmentsKeys.list(segment.ItemId!),
+    })
+  })
+
   /**
    * Property: DELETE request includes correct query parameters
    * For any valid segment, the DELETE request SHALL include

--- a/src/services/segments/mutations.ts
+++ b/src/services/segments/mutations.ts
@@ -28,10 +28,10 @@ interface OptimisticContext {
   rolledBack?: boolean
 }
 
-export const DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE =
+const DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE =
   'The server did not confirm the delete. Please try again.'
 
-export const DELETE_SEGMENT_INVALID_MESSAGE = 'Invalid or missing segment ID'
+const DELETE_SEGMENT_INVALID_MESSAGE = 'Invalid or missing segment ID'
 
 // Shared utilities
 const handleMutationError = (operation: string) => (error: unknown) => {
@@ -90,10 +90,6 @@ const rollbackSegments = (
   ctx.rolledBack = true
 }
 
-const throwCancelledMutation = () => {
-  throw new DOMException('Aborted', 'AbortError')
-}
-
 const validateDeleteInput = (segment: MediaSegmentDto) => {
   if (!isValidItemId(segment.Id)) {
     throw QueryError.validation(DELETE_SEGMENT_INVALID_MESSAGE)
@@ -109,7 +105,7 @@ export const useDeleteSegment = () => {
       validateDeleteInput(segment)
       const deleted = await deleteSegment(segment, { signal })
       if (!deleted) {
-        if (signal.aborted) throwCancelledMutation()
+        if (signal.aborted) throw new DOMException('Aborted', 'AbortError')
         throw new Error(DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE)
       }
       return deleted

--- a/src/services/segments/mutations.ts
+++ b/src/services/segments/mutations.ts
@@ -69,16 +69,17 @@ const rollbackSegments = (
   ctx: OptimisticContext,
 ) => {
   if (!previous) return
-  qc.setQueryData(segmentsKeys.list(itemId), previous)
   const current = qc.getQueryData<Array<MediaSegmentDto>>(
     segmentsKeys.list(itemId),
   )
-  if (
-    !current ||
-    current.length !== previous.length ||
-    !previous.every((s) => current.some((c) => c.Id === s.Id))
-  ) {
+  qc.setQueryData(segmentsKeys.list(itemId), previous)
+  if (!current || current.length !== previous.length) {
     void qc.invalidateQueries({ queryKey: segmentsKeys.list(itemId) })
+  } else {
+    const currentIds = new Set(current.map((segment) => segment.Id))
+    if (!previous.every((segment) => currentIds.has(segment.Id))) {
+      void qc.invalidateQueries({ queryKey: segmentsKeys.list(itemId) })
+    }
   }
   ctx.rolledBack = true
 }
@@ -88,10 +89,14 @@ export const useDeleteSegment = () => {
   const getController = useAbortController()
 
   return useMutation<boolean, QueryError, MediaSegmentDto, OptimisticContext>({
-    mutationFn: wrapMutationFn(
-      (segment, signal) => deleteSegment(segment, { signal }),
-      getController,
-    ),
+    mutationFn: wrapMutationFn(async (segment, signal) => {
+      const deleted = await deleteSegment(segment, { signal })
+      if (!deleted)
+        throw new Error(
+          'The server did not confirm the delete. Please try again.',
+        )
+      return deleted
+    }, getController),
     onMutate: async (segment) => {
       if (!segment.ItemId) return { rolledBack: false }
       await qc.cancelQueries({ queryKey: segmentsKeys.list(segment.ItemId) })

--- a/src/services/segments/mutations.ts
+++ b/src/services/segments/mutations.ts
@@ -14,7 +14,8 @@ import {
   handleQueryError,
 } from '@/hooks/queries/query-error-handling'
 import { showError, showSuccess } from '@/lib/notifications'
-import { isAbortError } from '@/lib/unified-error'
+import { ErrorCodes } from '@/lib/unified-error'
+import { isValidItemId } from '@/lib/schemas'
 
 interface BatchSaveInput {
   itemId: string
@@ -30,10 +31,12 @@ interface OptimisticContext {
 export const DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE =
   'The server did not confirm the delete. Please try again.'
 
+export const DELETE_SEGMENT_INVALID_MESSAGE = 'Invalid or missing segment ID'
+
 // Shared utilities
 const handleMutationError = (operation: string) => (error: unknown) => {
-  if (isAbortError(error)) return
   const e = QueryError.from(error)
+  if (e.code === ErrorCodes.CANCELLED) return
   handleQueryError(e, { operation })
   showError(
     `${operation} failed`,
@@ -87,14 +90,28 @@ const rollbackSegments = (
   ctx.rolledBack = true
 }
 
+const throwCancelledMutation = () => {
+  throw new DOMException('Aborted', 'AbortError')
+}
+
+const validateDeleteInput = (segment: MediaSegmentDto) => {
+  if (!isValidItemId(segment.Id)) {
+    throw QueryError.validation(DELETE_SEGMENT_INVALID_MESSAGE)
+  }
+}
+
 export const useDeleteSegment = () => {
   const qc = useQueryClient()
   const getController = useAbortController()
 
   return useMutation<boolean, QueryError, MediaSegmentDto, OptimisticContext>({
     mutationFn: wrapMutationFn(async (segment, signal) => {
+      validateDeleteInput(segment)
       const deleted = await deleteSegment(segment, { signal })
-      if (!deleted) throw new Error(DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE)
+      if (!deleted) {
+        if (signal.aborted) throwCancelledMutation()
+        throw new Error(DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE)
+      }
       return deleted
     }, getController),
     onMutate: async (segment) => {

--- a/src/services/segments/mutations.ts
+++ b/src/services/segments/mutations.ts
@@ -27,6 +27,9 @@ interface OptimisticContext {
   rolledBack?: boolean
 }
 
+export const DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE =
+  'The server did not confirm the delete. Please try again.'
+
 // Shared utilities
 const handleMutationError = (operation: string) => (error: unknown) => {
   if (isAbortError(error)) return
@@ -91,10 +94,7 @@ export const useDeleteSegment = () => {
   return useMutation<boolean, QueryError, MediaSegmentDto, OptimisticContext>({
     mutationFn: wrapMutationFn(async (segment, signal) => {
       const deleted = await deleteSegment(segment, { signal })
-      if (!deleted)
-        throw new Error(
-          'The server did not confirm the delete. Please try again.',
-        )
+      if (!deleted) throw new Error(DELETE_SEGMENT_NOT_CONFIRMED_MESSAGE)
       return deleted
     }, getController),
     onMutate: async (segment) => {


### PR DESCRIPTION
## Summary by Sourcery

Improve delete-segment rollback behavior and ensure cache consistency when optimistic deletions fail.

Bug Fixes:
- Ensure delete-segment mutation throws when the server does not confirm deletion, preventing silent failures.
- Fix rollback logic to always restore the previous segment cache and invalidate queries only when the cache contents have changed.

Tests:
- Add property tests verifying cache restoration and conditional query invalidation when optimistic segment deletion fails.