### PR TITLE
Extract playback-status and HLS-encoding hooks

### DIFF
--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -392,6 +392,35 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
         isPaused: true,
       })
     })
+
+    vi.mocked(reportPlaybackProgress).mockClear()
+    directVideo.currentTime = 35
+
+    act(() => {
+      directVideo.dispatchEvent(new Event('playing'))
+      directVideo.dispatchEvent(new Event('pause'))
+      directVideo.dispatchEvent(new Event('seeked'))
+    })
+
+    await waitFor(() => {
+      expect(reportPlaybackProgress).toHaveBeenCalledTimes(3)
+    })
+    expect(reportPlaybackProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playSessionId: 'direct-session-1',
+        playMethod: 'DirectPlay',
+        positionTicks: 350_000_000,
+        isPaused: false,
+      }),
+    )
+    expect(reportPlaybackProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playSessionId: 'direct-session-1',
+        playMethod: 'DirectPlay',
+        positionTicks: 350_000_000,
+        isPaused: true,
+      }),
+    )
   })
 
   it('stops active playback status and does not send further writes after sync is disabled', async () => {
@@ -665,6 +694,58 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
 
     expect(stopPlaybackStatusKeepalive).toHaveBeenCalledWith(
       expect.objectContaining({ positionTicks: 550_000_000 }),
+    )
+  })
+
+  it('does not start Transcode status with provisional HLS ID when config resolves to direct', async () => {
+    const configDeferred = createDeferred()
+    vi.mocked(createPlaySessionId)
+      .mockReturnValueOnce('unused-hls-init')
+      .mockReturnValueOnce('direct-session-1')
+    vi.mocked(getPlaybackConfig).mockReturnValue(
+      configDeferred.promise.then(() => ({
+        strategy: 'direct' as const,
+        url: 'https://jellyfin.example/Videos/item-1/stream',
+      })),
+    )
+
+    const { result } = renderVideoPlayer({ jellyfinPlaybackSyncEnabled: true })
+
+    await waitFor(() => {
+      expect(getPlaybackConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ Id: 'item-1' }),
+        undefined,
+        undefined,
+        false,
+        'unused-hls-init',
+      )
+    })
+
+    expect(startPlaybackStatus).not.toHaveBeenCalled()
+
+    act(() => {
+      configDeferred.resolve()
+    })
+
+    const directVideo = document.createElement('video')
+    directVideo.currentTime = 0
+    result.current.videoRef.current = directVideo
+
+    await waitFor(() => {
+      expect(result.current.strategy).toBe('direct')
+    })
+
+    await waitFor(() => {
+      expect(startPlaybackStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playSessionId: 'direct-session-1',
+          playMethod: 'DirectPlay',
+        }),
+      )
+    })
+
+    expect(startPlaybackStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ playMethod: 'Transcode' }),
     )
   })
 })

--- a/src/hooks/use-hls-encoding.ts
+++ b/src/hooks/use-hls-encoding.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffectEvent, useRef } from 'react'
+import {
+  stopActiveEncoding,
+  stopActiveEncodingKeepalive,
+} from '@/services/video/transcode-session'
+
+export interface UseHlsEncodingReturn {
+  /** Ref to the current HLS play session ID. Read by usePlaybackStatus to validate Transcode sessions. */
+  hlsPlaySessionIdRef: React.RefObject<string | null>
+  /** Set the current HLS play session ID. Pass null to clear (direct-play branch). */
+  setHlsPlaySessionId: (id: string | null) => void
+  /** Stop the current HLS encoding session (async, normal path). Clears the ref. */
+  stopCurrentHlsEncoding: () => Promise<void>
+  /** Stop the current HLS encoding session via keepalive fetch (pagehide path). Clears the ref. */
+  stopCurrentHlsEncodingKeepalive: () => void
+  /**
+   * Stop a specific previous HLS encoding session by explicit ID.
+   * Used during HLS reload when the session ID changes: the old session must be
+   * stopped before the new one is set.
+   */
+  stopPreviousHlsEncoding: (previousPlaySessionId: string) => Promise<void>
+}
+
+/**
+ * Manages the HLS encoding session lifecycle:
+ * - Owns the hlsPlaySessionId ref.
+ * - Provides set/clear, normal stop, keepalive stop, and stop-previous-explicit-id.
+ */
+export function useHlsEncoding(): UseHlsEncodingReturn {
+  const hlsPlaySessionIdRef = useRef<string | null>(null)
+
+  const setHlsPlaySessionId = useCallback((id: string | null) => {
+    hlsPlaySessionIdRef.current = id
+  }, [])
+
+  const stopCurrentHlsEncoding = useCallback(async () => {
+    const playSessionId = hlsPlaySessionIdRef.current
+    hlsPlaySessionIdRef.current = null
+    try {
+      await stopActiveEncoding({ playSessionId })
+    } catch (err) {
+      console.debug('Failed to stop Jellyfin active encoding', err)
+    }
+  }, [])
+
+  const stopCurrentHlsEncodingKeepalive = useEffectEvent(() => {
+    const playSessionId = hlsPlaySessionIdRef.current
+    hlsPlaySessionIdRef.current = null
+    stopActiveEncodingKeepalive({ playSessionId })
+  })
+
+  const stopPreviousHlsEncoding = useCallback(
+    async (previousPlaySessionId: string) => {
+      try {
+        await stopActiveEncoding({ playSessionId: previousPlaySessionId })
+      } catch (err) {
+        console.debug('Failed to stop previous Jellyfin active encoding', err)
+      }
+    },
+    [],
+  )
+
+  return {
+    hlsPlaySessionIdRef,
+    setHlsPlaySessionId,
+    stopCurrentHlsEncoding,
+    stopCurrentHlsEncodingKeepalive,
+    stopPreviousHlsEncoding,
+  }
+}

--- a/src/hooks/use-playback-status.ts
+++ b/src/hooks/use-playback-status.ts
@@ -1,0 +1,269 @@
+import { useCallback, useEffect, useEffectEvent, useRef } from 'react'
+import type { PlaybackStrategy } from '@/services/video/api'
+import { getPlaybackMediaSourceId } from '@/services/video/api'
+import type { PlaybackStatusPlayMethod } from '@/services/video/playback-session'
+import {
+  reportPlaybackProgress,
+  startPlaybackStatus,
+  stopPlaybackStatus,
+  stopPlaybackStatusKeepalive,
+} from '@/services/video/playback-session'
+import { createPlaySessionId } from '@/services/video/session'
+import { secondsToTicks } from '@/lib/time-utils'
+import type { BaseItemDto } from '@/types/jellyfin'
+
+interface ActivePlaybackStatusSession {
+  itemId: string
+  mediaSourceId: string
+  playSessionId: string
+  playMethod: PlaybackStatusPlayMethod
+  latestPositionTicks: number
+}
+
+interface UsePlaybackStatusOptions {
+  itemId: string | null
+  mediaSourceId: string | null
+  itemRef: React.RefObject<BaseItemDto | null>
+  isActiveRef: React.RefObject<boolean>
+  playbackRequestIdRef: React.RefObject<number>
+  playbackSyncEnabledRef: React.RefObject<boolean>
+  /** Ref to the current HLS play session ID (read-only from this hook's perspective) */
+  hlsPlaySessionIdRef: React.RefObject<string | null>
+  /**
+   * Ref to the current strategy. Using a ref (not state) ensures startCurrentPlaybackStatus
+   * reads the live strategy even when called synchronously after updateStrategy() within
+   * the same render cycle (e.g. switchToHls sets strategy to 'hls' then immediately starts).
+   */
+  currentStrategyRef: React.RefObject<PlaybackStrategy>
+  getActiveVideoElement: () => HTMLVideoElement | null
+  /**
+   * Strategy state value used as an explicit mode key for the event-listener effect.
+   * When strategy flips (direct <-> HLS), the effect re-runs and reattaches listeners
+   * to the correct video element.
+   */
+  strategy: PlaybackStrategy
+  jellyfinPlaybackSyncEnabled: boolean
+}
+
+export interface UsePlaybackStatusReturn {
+  /** Start playback status reporting. Optionally override the initial position ticks. */
+  startCurrentPlaybackStatus: (positionTicksOverride?: number) => Promise<void>
+  /** Stop playback status reporting (async, normal path). */
+  stopCurrentPlaybackStatus: () => Promise<void>
+  /** Stop playback status reporting via keepalive fetch (pagehide path). */
+  stopCurrentPlaybackStatusKeepalive: () => void
+}
+
+/**
+ * Manages Jellyfin playback status reporting lifecycle:
+ * - Owns the active session ref, start-id versioning, and position tracking.
+ * - Wires video event listeners (playing/pause/seeked/interval) to report progress.
+ * - Listener effect re-runs when strategy changes so the correct video element is observed.
+ */
+export function usePlaybackStatus({
+  itemId,
+  mediaSourceId,
+  itemRef,
+  isActiveRef,
+  playbackRequestIdRef,
+  playbackSyncEnabledRef,
+  hlsPlaySessionIdRef,
+  currentStrategyRef,
+  getActiveVideoElement,
+  strategy,
+  jellyfinPlaybackSyncEnabled,
+}: UsePlaybackStatusOptions): UsePlaybackStatusReturn {
+  const playbackStatusStartIdRef = useRef(0)
+  const activePlaybackStatusRef = useRef<ActivePlaybackStatusSession | null>(
+    null,
+  )
+
+  const getCurrentPositionTicks = useCallback((): number => {
+    const video = getActiveVideoElement()
+    const activeSession = activePlaybackStatusRef.current
+    if (video !== null) {
+      const currentTicks = secondsToTicks(video.currentTime)
+      if (activeSession) activeSession.latestPositionTicks = currentTicks
+      return currentTicks
+    }
+    return activeSession?.latestPositionTicks ?? 0
+  }, [getActiveVideoElement])
+
+  const startCurrentPlaybackStatus = useCallback(
+    async (positionTicksOverride?: number) => {
+      if (!playbackSyncEnabledRef.current || !itemId || !mediaSourceId) return
+      if (activePlaybackStatusRef.current) return
+
+      const startId = ++playbackStatusStartIdRef.current
+      const requestId = playbackRequestIdRef.current
+
+      const video = getActiveVideoElement()
+      const positionTicks =
+        positionTicksOverride ?? secondsToTicks(video?.currentTime ?? 0)
+      const playMethod: PlaybackStatusPlayMethod =
+        currentStrategyRef.current === 'hls' ? 'Transcode' : 'DirectPlay'
+      const playSessionId =
+        playMethod === 'Transcode'
+          ? hlsPlaySessionIdRef.current
+          : createPlaySessionId()
+
+      if (!playSessionId) return
+
+      const nextSession: ActivePlaybackStatusSession = {
+        itemId,
+        mediaSourceId,
+        playSessionId,
+        playMethod,
+        latestPositionTicks: positionTicks,
+      }
+
+      const isCurrentPlaybackStatusStart = () => {
+        const currentMediaSourceId = itemRef.current
+          ? (getPlaybackMediaSourceId(itemRef.current) ?? null)
+          : null
+
+        return (
+          isActiveRef.current &&
+          playbackSyncEnabledRef.current &&
+          playbackStatusStartIdRef.current === startId &&
+          playbackRequestIdRef.current === requestId &&
+          itemRef.current?.Id === itemId &&
+          currentMediaSourceId === mediaSourceId &&
+          !activePlaybackStatusRef.current &&
+          (playMethod !== 'Transcode' ||
+            hlsPlaySessionIdRef.current === playSessionId)
+        )
+      }
+
+      try {
+        if (!isCurrentPlaybackStatusStart()) return
+
+        await startPlaybackStatus({
+          itemId,
+          mediaSourceId,
+          playSessionId,
+          playMethod,
+          positionTicks,
+          isPaused: video?.paused ?? true,
+        })
+
+        if (!isCurrentPlaybackStatusStart()) {
+          void stopPlaybackStatus({
+            ...nextSession,
+            positionTicks: nextSession.latestPositionTicks,
+          }).catch((err) => {
+            console.debug('Failed to stop stale Jellyfin playback status', err)
+          })
+          return
+        }
+
+        activePlaybackStatusRef.current = nextSession
+      } catch (err) {
+        console.debug('Failed to start Jellyfin playback status reporting', err)
+      }
+    },
+    [
+      currentStrategyRef,
+      getActiveVideoElement,
+      hlsPlaySessionIdRef,
+      isActiveRef,
+      itemId,
+      itemRef,
+      mediaSourceId,
+      playbackRequestIdRef,
+      playbackSyncEnabledRef,
+    ],
+  )
+
+  const consumeActivePlaybackStatus = useCallback(() => {
+    const activeSession = activePlaybackStatusRef.current
+    const finalPositionTicks = getCurrentPositionTicks()
+    activePlaybackStatusRef.current = null
+    playbackStatusStartIdRef.current++
+
+    return { activeSession, finalPositionTicks }
+  }, [getCurrentPositionTicks])
+
+  const stopCurrentPlaybackStatus = useCallback(async () => {
+    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
+    if (!activeSession) return
+
+    try {
+      await stopPlaybackStatus({
+        ...activeSession,
+        positionTicks: finalPositionTicks,
+      })
+    } catch (err) {
+      console.debug('Failed to stop Jellyfin playback status reporting', err)
+    }
+  }, [consumeActivePlaybackStatus])
+
+  const stopCurrentPlaybackStatusKeepalive = useEffectEvent(() => {
+    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
+    if (!activeSession) return
+
+    stopPlaybackStatusKeepalive({
+      ...activeSession,
+      positionTicks: finalPositionTicks,
+    })
+  })
+
+  const reportCurrentPlaybackProgress = useEffectEvent(
+    async (isPaused: boolean) => {
+      const activeSession = activePlaybackStatusRef.current
+      if (!playbackSyncEnabledRef.current || !activeSession) return
+
+      try {
+        await reportPlaybackProgress({
+          ...activeSession,
+          positionTicks: getCurrentPositionTicks(),
+          isPaused,
+        })
+      } catch (err) {
+        console.debug('Failed to report Jellyfin playback progress', err)
+      }
+    },
+  )
+
+  // Wire video event listeners. Re-runs when strategy changes so the correct
+  // video element (HLS vs direct) is observed after a mode switch.
+  useEffect(() => {
+    if (!jellyfinPlaybackSyncEnabled || !itemId) return
+
+    const video = getActiveVideoElement()
+    if (!video) return
+
+    const handlePlaying = () => {
+      void reportCurrentPlaybackProgress(false)
+    }
+    const handlePause = () => {
+      void reportCurrentPlaybackProgress(true)
+    }
+    const handleSeeked = () => {
+      void reportCurrentPlaybackProgress(video.paused)
+    }
+    const intervalId = window.setInterval(() => {
+      if (!video.paused) void reportCurrentPlaybackProgress(false)
+    }, 15_000)
+
+    video.addEventListener('playing', handlePlaying)
+    video.addEventListener('pause', handlePause)
+    video.addEventListener('seeked', handleSeeked)
+
+    return () => {
+      window.clearInterval(intervalId)
+      video.removeEventListener('playing', handlePlaying)
+      video.removeEventListener('pause', handlePause)
+      video.removeEventListener('seeked', handleSeeked)
+    }
+    // strategy is the explicit mode key that forces reattachment on direct<->HLS switch.
+    // getActiveVideoElement is stable (useCallback with stable deps) so including it is safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jellyfinPlaybackSyncEnabled, itemId, strategy, getActiveVideoElement])
+
+  return {
+    startCurrentPlaybackStatus,
+    stopCurrentPlaybackStatus,
+    stopCurrentPlaybackStatusKeepalive,
+  }
+}

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -13,20 +13,11 @@ import {
   restorePlaybackStateSync,
 } from '@/services/video/playback-state'
 import { createPlaySessionId } from '@/services/video/session'
-import {
-  stopActiveEncoding,
-  stopActiveEncodingKeepalive,
-} from '@/services/video/transcode-session'
-import {
-  reportPlaybackProgress,
-  startPlaybackStatus,
-  stopPlaybackStatus,
-  stopPlaybackStatusKeepalive,
-} from '@/services/video/playback-session'
-import type { PlaybackStatusPlayMethod } from '@/services/video/playback-session'
 import { secondsToTicks } from '@/lib/time-utils'
 import { useHlsPlayer } from '@/hooks/use-hls-player'
 import type { HlsPlayerError } from '@/hooks/use-hls-player'
+import { useHlsEncoding } from '@/hooks/use-hls-encoding'
+import { usePlaybackStatus } from '@/hooks/use-playback-status'
 
 export type VideoPlayerErrorType =
   | 'media_error'
@@ -61,14 +52,6 @@ interface UseVideoPlayerReturn {
   retry: () => void
   videoUrl: string
   reloadHlsWithUrl: (reload: HlsReloadRequest) => Promise<void>
-}
-
-interface ActivePlaybackStatusSession {
-  itemId: string
-  mediaSourceId: string
-  playSessionId: string
-  playMethod: PlaybackStatusPlayMethod
-  latestPositionTicks: number
 }
 
 function mapMediaErrorCode(code: number): VideoPlayerErrorType {
@@ -130,15 +113,10 @@ export function useVideoPlayer({
   const pendingHlsStateRestoreRef = useRef(false)
   const isActiveRef = useRef(true)
   const playbackRequestIdRef = useRef(0)
-  const playbackStatusStartIdRef = useRef(0)
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const emptyHlsRef = useRef<Hls | null>(null)
   const currentStrategyRef = useRef<PlaybackStrategy>('hls')
-  const hlsPlaySessionIdRef = useRef<string | null>(null)
   const playbackSyncEnabledRef = useRef(jellyfinPlaybackSyncEnabled)
-  const activePlaybackStatusRef = useRef<ActivePlaybackStatusSession | null>(
-    null,
-  )
   /** Guards against error handler firing during intentional strategy switches (e.g. audio track switch) */
   const intentionalSwitchRef = useRef(false)
   const hlsRestoreVideoRef = useRef<HTMLVideoElement | null>(null)
@@ -157,21 +135,14 @@ export function useVideoPlayer({
     preservedStateItemIdRef.current = null
   }, [])
 
-  const stopCurrentHlsEncoding = useCallback(async () => {
-    const playSessionId = hlsPlaySessionIdRef.current
-    hlsPlaySessionIdRef.current = null
-    try {
-      await stopActiveEncoding({ playSessionId })
-    } catch (err) {
-      console.debug('Failed to stop Jellyfin active encoding', err)
-    }
-  }, [])
-
-  const stopCurrentHlsEncodingKeepalive = useEffectEvent(() => {
-    const playSessionId = hlsPlaySessionIdRef.current
-    hlsPlaySessionIdRef.current = null
-    stopActiveEncodingKeepalive({ playSessionId })
-  })
+  const hlsEncoding = useHlsEncoding()
+  const {
+    hlsPlaySessionIdRef,
+    setHlsPlaySessionId,
+    stopCurrentHlsEncoding,
+    stopCurrentHlsEncodingKeepalive,
+    stopPreviousHlsEncoding,
+  } = hlsEncoding
 
   const setPreservedState = useCallback(
     (
@@ -250,142 +221,25 @@ export function useVideoPlayer({
       : videoRef.current
   }, [hlsPlayer.videoRef])
 
-  const getCurrentPositionTicks = useCallback((): number => {
-    const video = getActiveVideoElement()
-    const activeSession = activePlaybackStatusRef.current
-    if (video !== null) {
-      const currentTicks = secondsToTicks(video.currentTime)
-      if (activeSession) activeSession.latestPositionTicks = currentTicks
-      return currentTicks
-    }
-    return activeSession?.latestPositionTicks ?? 0
-  }, [getActiveVideoElement])
-
-  const startCurrentPlaybackStatus = useCallback(
-    async (positionTicksOverride?: number) => {
-      if (!playbackSyncEnabledRef.current || !itemId || !mediaSourceId) return
-      if (activePlaybackStatusRef.current) return
-
-      const startId = ++playbackStatusStartIdRef.current
-      const requestId = playbackRequestIdRef.current
-
-      const video = getActiveVideoElement()
-      const positionTicks =
-        positionTicksOverride ?? secondsToTicks(video?.currentTime ?? 0)
-      const playMethod: PlaybackStatusPlayMethod =
-        currentStrategyRef.current === 'hls' ? 'Transcode' : 'DirectPlay'
-      const playSessionId =
-        playMethod === 'Transcode'
-          ? hlsPlaySessionIdRef.current
-          : createPlaySessionId()
-
-      if (!playSessionId) return
-
-      const nextSession: ActivePlaybackStatusSession = {
-        itemId,
-        mediaSourceId,
-        playSessionId,
-        playMethod,
-        latestPositionTicks: positionTicks,
-      }
-
-      const isCurrentPlaybackStatusStart = () => {
-        const currentMediaSourceId = itemRef.current
-          ? (getPlaybackMediaSourceId(itemRef.current) ?? null)
-          : null
-
-        return (
-          isActiveRef.current &&
-          playbackSyncEnabledRef.current &&
-          playbackStatusStartIdRef.current === startId &&
-          playbackRequestIdRef.current === requestId &&
-          itemRef.current?.Id === itemId &&
-          currentMediaSourceId === mediaSourceId &&
-          !activePlaybackStatusRef.current &&
-          (playMethod !== 'Transcode' ||
-            hlsPlaySessionIdRef.current === playSessionId)
-        )
-      }
-
-      try {
-        if (!isCurrentPlaybackStatusStart()) return
-
-        await startPlaybackStatus({
-          itemId,
-          mediaSourceId,
-          playSessionId,
-          playMethod,
-          positionTicks,
-          isPaused: video?.paused ?? true,
-        })
-
-        if (!isCurrentPlaybackStatusStart()) {
-          void stopPlaybackStatus({
-            ...nextSession,
-            positionTicks: nextSession.latestPositionTicks,
-          }).catch((err) => {
-            console.debug('Failed to stop stale Jellyfin playback status', err)
-          })
-          return
-        }
-
-        activePlaybackStatusRef.current = nextSession
-      } catch (err) {
-        console.debug('Failed to start Jellyfin playback status reporting', err)
-      }
-    },
-    [getActiveVideoElement, itemId, mediaSourceId],
-  )
-
-  const reportCurrentPlaybackProgress = useEffectEvent(
-    async (isPaused: boolean) => {
-      const activeSession = activePlaybackStatusRef.current
-      if (!playbackSyncEnabledRef.current || !activeSession) return
-
-      try {
-        await reportPlaybackProgress({
-          ...activeSession,
-          positionTicks: getCurrentPositionTicks(),
-          isPaused,
-        })
-      } catch (err) {
-        console.debug('Failed to report Jellyfin playback progress', err)
-      }
-    },
-  )
-
-  const consumeActivePlaybackStatus = useCallback(() => {
-    const activeSession = activePlaybackStatusRef.current
-    const finalPositionTicks = getCurrentPositionTicks()
-    activePlaybackStatusRef.current = null
-    playbackStatusStartIdRef.current++
-
-    return { activeSession, finalPositionTicks }
-  }, [getCurrentPositionTicks])
-
-  const stopCurrentPlaybackStatus = useCallback(async () => {
-    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
-    if (!activeSession) return
-
-    try {
-      await stopPlaybackStatus({
-        ...activeSession,
-        positionTicks: finalPositionTicks,
-      })
-    } catch (err) {
-      console.debug('Failed to stop Jellyfin playback status reporting', err)
-    }
-  }, [consumeActivePlaybackStatus])
-
-  const stopCurrentPlaybackStatusKeepalive = useEffectEvent(() => {
-    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
-    if (!activeSession) return
-
-    stopPlaybackStatusKeepalive({
-      ...activeSession,
-      positionTicks: finalPositionTicks,
-    })
+  const playbackStatus = usePlaybackStatus({
+    itemId,
+    mediaSourceId,
+    itemRef,
+    isActiveRef,
+    playbackRequestIdRef,
+    playbackSyncEnabledRef,
+    hlsPlaySessionIdRef: hlsPlaySessionIdRef,
+    currentStrategyRef,
+    getActiveVideoElement,
+    strategy,
+    jellyfinPlaybackSyncEnabled,
   })
+
+  const {
+    startCurrentPlaybackStatus,
+    stopCurrentPlaybackStatus,
+    stopCurrentPlaybackStatusKeepalive,
+  } = playbackStatus
 
   const restoreStateAndMaybeResume = useCallback(
     (video: HTMLVideoElement, state: PlaybackState) => {
@@ -507,7 +361,7 @@ export function useVideoPlayer({
         )
         if (isCurrentHlsRequest()) {
           const hlsUrl = config.strategy === 'hls' ? config.url : ''
-          hlsPlaySessionIdRef.current = hlsPlaySessionId
+          setHlsPlaySessionId(hlsPlaySessionId)
 
           setError(null)
           updateStrategy('hls')
@@ -519,6 +373,7 @@ export function useVideoPlayer({
       }
     },
     [
+      setHlsPlaySessionId,
       itemId,
       onStrategyChange,
       playbackRequestIdRef,
@@ -662,11 +517,9 @@ export function useVideoPlayer({
         )
 
         if (playbackRequestIdRef.current === requestId) {
-          if (config.strategy === 'hls') {
-            hlsPlaySessionIdRef.current = hlsPlaySessionId
-          } else {
-            hlsPlaySessionIdRef.current = null
-          }
+          setHlsPlaySessionId(
+            config.strategy === 'hls' ? hlsPlaySessionId : null,
+          )
 
           handleInitPlaybackSuccess(config, itemId)
           await startCurrentPlaybackStatus()
@@ -714,41 +567,9 @@ export function useVideoPlayer({
     setPreservedState,
     startCurrentPlaybackStatus,
     stopCurrentPlaybackStatus,
+    setHlsPlaySessionId,
     stopCurrentHlsEncoding,
   ])
-
-  const activeVideoRef = strategy === 'hls' ? hlsPlayer.videoRef : videoRef
-
-  useEffect(() => {
-    if (!jellyfinPlaybackSyncEnabled || !itemId) return
-
-    const video = activeVideoRef.current
-    if (!video) return
-
-    const handlePlaying = () => {
-      void reportCurrentPlaybackProgress(false)
-    }
-    const handlePause = () => {
-      void reportCurrentPlaybackProgress(true)
-    }
-    const handleSeeked = () => {
-      void reportCurrentPlaybackProgress(video.paused)
-    }
-    const intervalId = window.setInterval(() => {
-      if (!video.paused) void reportCurrentPlaybackProgress(false)
-    }, 15_000)
-
-    video.addEventListener('playing', handlePlaying)
-    video.addEventListener('pause', handlePause)
-    video.addEventListener('seeked', handleSeeked)
-
-    return () => {
-      window.clearInterval(intervalId)
-      video.removeEventListener('playing', handlePlaying)
-      video.removeEventListener('pause', handlePause)
-      video.removeEventListener('seeked', handleSeeked)
-    }
-  }, [jellyfinPlaybackSyncEnabled, itemId, activeVideoRef, strategy])
 
   useEffect(() => {
     if (strategy !== 'direct' || !videoUrl) return
@@ -815,13 +636,9 @@ export function useVideoPlayer({
         previousHlsPlaySessionId &&
         previousHlsPlaySessionId !== nextHlsPlaySessionId
       ) {
-        try {
-          await stopActiveEncoding({ playSessionId: previousHlsPlaySessionId })
-        } catch (err) {
-          console.debug('Failed to stop previous Jellyfin active encoding', err)
-        }
+        await stopPreviousHlsEncoding(previousHlsPlaySessionId)
       }
-      hlsPlaySessionIdRef.current = nextHlsPlaySessionId
+      setHlsPlaySessionId(nextHlsPlaySessionId)
 
       setError(null)
 
@@ -851,6 +668,9 @@ export function useVideoPlayer({
       void startCurrentPlaybackStatus(activePositionTicks)
     },
     [
+      hlsPlaySessionIdRef,
+      stopPreviousHlsEncoding,
+      setHlsPlaySessionId,
       itemId,
       getActiveVideoElement,
       onStrategyChange,
@@ -862,6 +682,7 @@ export function useVideoPlayer({
     ],
   )
 
+  const activeVideoRef = strategy === 'hls' ? hlsPlayer.videoRef : videoRef
   const activeHlsRef = strategy === 'hls' ? hlsPlayer.hlsRef : emptyHlsRef
 
   const itemKey = itemId


### PR DESCRIPTION
## Summary by Sourcery

Extract playback status and HLS encoding lifecycle management from useVideoPlayer into dedicated hooks and tighten playback sync behavior.

New Features:
- Introduce a usePlaybackStatus hook to encapsulate Jellyfin playback status session management and progress reporting.
- Introduce a useHlsEncoding hook to encapsulate HLS transcode session lifecycle and play session ID handling.

Enhancements:
- Refactor useVideoPlayer to delegate playback status and HLS encoding responsibilities to the new hooks, reducing its internal state and side-effect complexity.
- Adjust playback sync so playback progress is reported on video playing, pause, and seek events for direct playback as well as HLS.
- Ensure playback status does not start a Transcode session when an initial HLS configuration resolves to direct playback.

Tests:
- Extend playback-sync tests to cover event-driven progress reporting and to verify that Transcode status is not started when the final strategy is direct.