### PR TITLE
Fix TypeScript errors in playback sync test

### DIFF
--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -97,7 +97,9 @@ type RenderVideoPlayerProps = {
   onStrategyChange?: (strategy: PlaybackStrategy) => void
 }
 
-function renderVideoPlayer(options?: Partial<RenderVideoPlayerProps>) {
+type RenderVideoPlayerOptions = Partial<RenderVideoPlayerProps>
+
+function renderVideoPlayer(options?: RenderVideoPlayerOptions) {
   const initialProps: RenderVideoPlayerProps = {
     item: options?.item ?? createItem(),
     jellyfinPlaybackSyncEnabled: options?.jellyfinPlaybackSyncEnabled ?? false,

--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -91,21 +91,28 @@ function createItem(id = 'item-1'): BaseItemDto {
   } as BaseItemDto
 }
 
-function renderVideoPlayer(options?: {
-  item?: BaseItemDto
-  jellyfinPlaybackSyncEnabled?: boolean
+type RenderVideoPlayerProps = {
+  item: BaseItemDto
+  jellyfinPlaybackSyncEnabled: boolean
   onStrategyChange?: (strategy: PlaybackStrategy) => void
-}) {
+}
+
+function renderVideoPlayer(options?: Partial<RenderVideoPlayerProps>) {
+  const initialProps: RenderVideoPlayerProps = {
+    item: options?.item ?? createItem(),
+    jellyfinPlaybackSyncEnabled: options?.jellyfinPlaybackSyncEnabled ?? false,
+  }
+
+  if (options?.onStrategyChange !== undefined) {
+    initialProps.onStrategyChange = options.onStrategyChange
+  }
+
   return renderHook(
     ({
       item,
       jellyfinPlaybackSyncEnabled,
       onStrategyChange,
-    }: {
-      item: BaseItemDto
-      jellyfinPlaybackSyncEnabled: boolean
-      onStrategyChange?: (strategy: PlaybackStrategy) => void
-    }) =>
+    }: RenderVideoPlayerProps) =>
       useVideoPlayer({
         item,
         jellyfinPlaybackSyncEnabled,
@@ -113,12 +120,7 @@ function renderVideoPlayer(options?: {
         t: (key) => key,
       }),
     {
-      initialProps: {
-        item: options?.item ?? createItem(),
-        jellyfinPlaybackSyncEnabled:
-          options?.jellyfinPlaybackSyncEnabled ?? false,
-        onStrategyChange: options?.onStrategyChange,
-      },
+      initialProps,
     },
   )
 }


### PR DESCRIPTION
This PR resolves `pnpm tsc --noEmit` errors in the playback sync test suite.

- Refactor `renderVideoPlayer` helper in `src/__tests__/use-video-player.playback-sync.test.tsx` to correctly construct props for `useVideoPlayer`.
- Fix optional `onStrategyChange` handling by conditionally assigning it to the props object to ensure strict type compliance.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/02de310e-8f1a-4bf4-838e-21b6e197283c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-027" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/02de310e-8f1a-4bf4-838e-21b6e197283c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-027&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-027"><img alt="INTRO-027" src="https://capy.ai/api/badge/thread.svg?label=INTRO-027"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Tests:
- Update the renderVideoPlayer test helper to build initial props via a dedicated typed props object and optional strategy change handler for stricter TypeScript compliance.