### PR TITLE
Refactor Jellyfin playback status handling

### DIFF
--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -255,6 +255,80 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
       )
     })
   })
+  it('preserves direct-play position when synced direct play falls back to HLS', async () => {
+    vi.stubGlobal('MediaError', {
+      MEDIA_ERR_ABORTED: 1,
+      MEDIA_ERR_NETWORK: 2,
+      MEDIA_ERR_DECODE: 3,
+      MEDIA_ERR_SRC_NOT_SUPPORTED: 4,
+    })
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(
+      () => undefined,
+    )
+    vi.mocked(createPlaySessionId)
+      .mockReturnValueOnce('unused-initial-hls-session')
+      .mockReturnValueOnce('direct-session-1')
+      .mockReturnValueOnce('hls-session-1')
+    vi.mocked(getPlaybackConfig)
+      .mockResolvedValueOnce({
+        strategy: 'direct',
+        url: 'https://jellyfin.example/Videos/item-1/stream',
+      })
+      .mockResolvedValueOnce({
+        strategy: 'hls',
+        url: 'https://jellyfin.example/Videos/item-1/master.m3u8?PlaySessionId=hls-session-1',
+      })
+
+    function Harness() {
+      const player = useVideoPlayer({
+        item: createItem(),
+        jellyfinPlaybackSyncEnabled: true,
+        t: (key) => key,
+      })
+      return (
+        <video ref={player.videoRef}>
+          <track kind="captions" label="Captions" src="data:text/vtt,WEBVTT" />
+        </video>
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const video = container.querySelector('video')!
+
+    await waitFor(() => {
+      expect(startPlaybackStatus).toHaveBeenCalledWith({
+        itemId: 'item-1',
+        mediaSourceId: 'item-1-media-source',
+        playSessionId: 'direct-session-1',
+        playMethod: 'DirectPlay',
+        positionTicks: 0,
+        isPaused: true,
+      })
+    })
+
+    video.currentTime = 42
+    vi.mocked(startPlaybackStatus).mockClear()
+
+    Object.defineProperty(video, 'error', {
+      configurable: true,
+      value: { code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED },
+    })
+
+    act(() => {
+      video.dispatchEvent(new Event('error'))
+    })
+
+    await waitFor(() => {
+      expect(startPlaybackStatus).toHaveBeenCalledWith({
+        itemId: 'item-1',
+        mediaSourceId: 'item-1-media-source',
+        playSessionId: 'hls-session-1',
+        playMethod: 'Transcode',
+        positionTicks: 420_000_000,
+        isPaused: true,
+      })
+    })
+  })
 
   it('stops stale pending playback status after sync is disabled mid-start', async () => {
     const startDeferred = createDeferred()

--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -342,6 +342,7 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
       expect(startPlaybackStatus).toHaveBeenCalledTimes(1)
     })
 
+    hlsMocks.videoRef.current!.currentTime = 34
     rerender({ item: createItem(), jellyfinPlaybackSyncEnabled: false })
 
     await act(async () => {
@@ -361,7 +362,7 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
         itemId: 'item-1',
         mediaSourceId: 'item-1-media-source',
         playSessionId: 'hls-session-1',
-        positionTicks: 120_000_000,
+        positionTicks: 340_000_000,
       }),
     )
     expect(vi.mocked(stopPlaybackStatus).mock.calls[0]?.[0]).not.toHaveProperty(

--- a/src/__tests__/use-video-player.playback-sync.test.tsx
+++ b/src/__tests__/use-video-player.playback-sync.test.tsx
@@ -286,14 +286,17 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
         t: (key) => key,
       })
       return (
-        <video ref={player.videoRef}>
+        <video
+          key={player.strategy}
+          data-strategy={player.strategy}
+          ref={player.videoRef}
+        >
           <track kind="captions" label="Captions" src="data:text/vtt,WEBVTT" />
         </video>
       )
     }
 
     const { container } = render(<Harness />)
-    const video = container.querySelector('video')!
 
     await waitFor(() => {
       expect(startPlaybackStatus).toHaveBeenCalledWith({
@@ -306,16 +309,20 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
       })
     })
 
-    video.currentTime = 42
+    const directVideo = container.querySelector<HTMLVideoElement>(
+      'video[data-strategy="direct"]',
+    )
+    expect(directVideo).not.toBeNull()
+    directVideo!.currentTime = 42
     vi.mocked(startPlaybackStatus).mockClear()
 
-    Object.defineProperty(video, 'error', {
+    Object.defineProperty(directVideo, 'error', {
       configurable: true,
       value: { code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED },
     })
 
     act(() => {
-      video.dispatchEvent(new Event('error'))
+      directVideo!.dispatchEvent(new Event('error'))
     })
 
     await waitFor(() => {
@@ -328,6 +335,15 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
         isPaused: true,
       })
     })
+    expect(stopPlaybackStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: 'item-1',
+        mediaSourceId: 'item-1-media-source',
+        playSessionId: 'direct-session-1',
+        playMethod: 'DirectPlay',
+        positionTicks: 420_000_000,
+      }),
+    )
   })
 
   it('stops stale pending playback status after sync is disabled mid-start', async () => {
@@ -537,6 +553,60 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
     })
   })
 
+  it('preserves pending playback position when stopping without a video element', async () => {
+    const startDeferred = createDeferred()
+    vi.mocked(startPlaybackStatus).mockReturnValue(startDeferred.promise)
+
+    const video = document.createElement('video')
+    video.currentTime = 12
+    let activeVideo: HTMLVideoElement | null = video
+    const session = {
+      itemId: 'item-1',
+      mediaSourceId: 'item-1-media-source',
+      playSessionId: 'hls-session-1',
+      strategy: 'hls' as const,
+      syncEnabled: true,
+    }
+
+    const { result } = renderHook(() =>
+      useJellyfinSession({
+        session,
+        getActiveVideoElement: () => activeVideo,
+      }),
+    )
+
+    let startPromise = Promise.resolve()
+    act(() => {
+      startPromise = result.current.startPlaybackStatus()
+    })
+
+    await waitFor(() => {
+      expect(startPlaybackStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ positionTicks: 120_000_000 }),
+      )
+    })
+
+    activeVideo = null
+
+    await act(async () => {
+      await result.current.stopPlaybackStatus()
+    })
+
+    await act(async () => {
+      startDeferred.resolve()
+      await startPromise
+    })
+
+    await waitFor(() => {
+      expect(stopPlaybackStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playSessionId: 'hls-session-1',
+          positionTicks: 120_000_000,
+        }),
+      )
+    })
+  })
+
   it('sends keepalive stop on pagehide for an active synced session', async () => {
     renderVideoPlayer({ jellyfinPlaybackSyncEnabled: true })
 
@@ -631,6 +701,76 @@ describe('useVideoPlayer Jellyfin playback sync', () => {
     await act(async () => {
       startDeferred.resolve()
       await startDeferred.promise
+    })
+
+    expect(stopPlaybackStatus).not.toHaveBeenCalled()
+  })
+  it('keeps stale pending keepalive stop on the original session position after item change', async () => {
+    const startDeferred = createDeferred()
+    vi.mocked(startPlaybackStatus).mockReturnValue(startDeferred.promise)
+
+    const originalVideo = document.createElement('video')
+    originalVideo.currentTime = 12
+    const nextVideo = document.createElement('video')
+    nextVideo.currentTime = 99
+    let activeVideo: HTMLVideoElement | null = originalVideo
+    const originalSession = {
+      itemId: 'item-1',
+      mediaSourceId: 'item-1-media-source',
+      playSessionId: 'hls-session-1',
+      strategy: 'hls' as const,
+      syncEnabled: true,
+    }
+    const nextSession = {
+      itemId: 'item-2',
+      mediaSourceId: 'item-2-media-source',
+      playSessionId: 'hls-session-2',
+      strategy: 'hls' as const,
+      syncEnabled: true,
+    }
+
+    const { result, rerender } = renderHook(
+      ({ session }) =>
+        useJellyfinSession({
+          session,
+          getActiveVideoElement: () => activeVideo,
+        }),
+      { initialProps: { session: originalSession } },
+    )
+
+    let startPromise = Promise.resolve()
+    act(() => {
+      startPromise = result.current.startPlaybackStatus()
+    })
+
+    await waitFor(() => {
+      expect(startPlaybackStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playSessionId: 'hls-session-1',
+          positionTicks: 120_000_000,
+        }),
+      )
+    })
+
+    activeVideo = nextVideo
+    rerender({ session: nextSession })
+
+    act(() => {
+      result.current.stopAllKeepalive()
+    })
+
+    expect(stopPlaybackStatusKeepalive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: 'item-1',
+        mediaSourceId: 'item-1-media-source',
+        playSessionId: 'hls-session-1',
+        positionTicks: 120_000_000,
+      }),
+    )
+
+    await act(async () => {
+      startDeferred.resolve()
+      await startPromise
     })
 
     expect(stopPlaybackStatus).not.toHaveBeenCalled()

--- a/src/hooks/use-jellyfin-session.ts
+++ b/src/hooks/use-jellyfin-session.ts
@@ -98,6 +98,9 @@ function isCurrentStartingPlaybackStatus(
   currentDescriptor: JellyfinSessionDescriptor | null,
   currentStartToken: number,
 ): boolean {
+  // A starting status is current only while the exact object is installed, its
+  // token is still the latest token, sync remains enabled, and the descriptor
+  // still matches the session that issued the start request.
   return (
     currentStatus === startingStatus &&
     startingStatus.startToken === currentStartToken &&
@@ -123,6 +126,8 @@ export function useJellyfinSession({
   currentSessionRef.current = session
 
   const markStartingPlaybackStatusInvalid = useCallback(() => {
+    // Invalidate in-flight starts without dropping the starting state; a later
+    // same-descriptor start can refresh the token and reuse the network request.
     nextStartTokenRef.current++
   }, [])
 
@@ -158,6 +163,8 @@ export function useJellyfinSession({
     const status = playbackStatusRef.current
     if (status.state !== 'starting') return
 
+    // Only refresh pending position from the video when it still belongs to this
+    // descriptor. Stale starts must keep their original stored position.
     if (isSameSessionDescriptor(currentSessionRef.current, status.descriptor)) {
       status.session.latestPositionTicks = getCurrentPositionTicks()
     }
@@ -168,6 +175,8 @@ export function useJellyfinSession({
     const status = playbackStatusRef.current
     if (status.state !== 'starting') return null
 
+    // Pagehide may run after the app moved to another item. In that case, do not
+    // read the current video element; it belongs to the new descriptor.
     const latestPositionTicks = status.session.latestPositionTicks
     const currentPositionTicks = isSameSessionDescriptor(
       currentSessionRef.current,

--- a/src/hooks/use-jellyfin-session.ts
+++ b/src/hooks/use-jellyfin-session.ts
@@ -28,13 +28,21 @@ interface ActivePlaybackStatusSession {
   playMethod: PlaybackStatusPlayMethod
   latestPositionTicks: number
 }
+type StartingPlaybackStatus = Extract<PlaybackStatus, { state: 'starting' }>
 
-interface PendingPlaybackStatusSession {
-  descriptor: JellyfinSessionDescriptor
-  session: ActivePlaybackStatusSession
-  startId: number
-  stopQueuedWithKeepalive?: boolean
-}
+type PlaybackStatus =
+  | { state: 'idle' }
+  | {
+      state: 'starting'
+      descriptor: JellyfinSessionDescriptor
+      session: ActivePlaybackStatusSession
+      startToken: number
+      stopQueuedWithKeepalive?: boolean
+    }
+  | {
+      state: 'active'
+      session: ActivePlaybackStatusSession
+    }
 
 interface UseJellyfinSessionOptions {
   session: JellyfinSessionDescriptor | null
@@ -71,7 +79,7 @@ function createActiveSession(
   }
 }
 
-function isSameSession(
+function isSameSessionDescriptor(
   left: JellyfinSessionDescriptor | null,
   right: JellyfinSessionDescriptor,
 ): boolean {
@@ -84,16 +92,42 @@ function isSameSession(
   )
 }
 
-function isSameActiveSession(
-  activeSession: ActivePlaybackStatusSession,
-  descriptor: JellyfinSessionDescriptor,
+function createPlaybackStatusPayload(
+  session: ActivePlaybackStatusSession,
+  positionTicks: number,
+  isPaused: boolean,
+) {
+  return {
+    itemId: session.itemId,
+    mediaSourceId: session.mediaSourceId,
+    playSessionId: session.playSessionId,
+    playMethod: session.playMethod,
+    positionTicks,
+    isPaused,
+  }
+}
+
+function isCurrentStartingPlaybackStatus(
+  currentStatus: PlaybackStatus,
+  startingStatus: StartingPlaybackStatus,
+  currentDescriptor: JellyfinSessionDescriptor | null,
+  currentStartToken: number,
 ): boolean {
   return (
-    activeSession.itemId === descriptor.itemId &&
-    activeSession.mediaSourceId === descriptor.mediaSourceId &&
-    activeSession.playSessionId === descriptor.playSessionId &&
-    activeSession.playMethod === playMethodForStrategy(descriptor.strategy)
+    currentStatus === startingStatus &&
+    startingStatus.startToken === currentStartToken &&
+    currentDescriptor?.syncEnabled === true &&
+    isSameSessionDescriptor(currentDescriptor, startingStatus.descriptor)
   )
+}
+
+function promoteStartingPlaybackStatus(
+  startingStatus: StartingPlaybackStatus,
+): PlaybackStatus {
+  return {
+    state: 'active',
+    session: startingStatus.session,
+  }
 }
 
 export function useJellyfinSession({
@@ -101,22 +135,25 @@ export function useJellyfinSession({
   getActiveVideoElement,
 }: UseJellyfinSessionOptions): UseJellyfinSessionReturn {
   const currentSessionRef = useRef<JellyfinSessionDescriptor | null>(session)
-  const playbackStatusStartIdRef = useRef(0)
-  const activePlaybackStatusRef = useRef<ActivePlaybackStatusSession | null>(
-    null,
-  )
-  const pendingPlaybackStatusRef = useRef<PendingPlaybackStatusSession | null>(
-    null,
-  )
+  const playbackStatusRef = useRef<PlaybackStatus>({ state: 'idle' })
+  const nextStartTokenRef = useRef(0)
+  // --- HLS encoding tracking (transcode lifecycle) ---
+  // Playback status owns Jellyfin progress writes (start/progress/stop).
+  // Encoding ref owns transcode cleanup (stopActiveEncoding).
   const hlsEncodingPlaySessionIdRef = useRef<string | null>(
     session?.strategy === 'hls' ? session.playSessionId : null,
   )
 
   currentSessionRef.current = session
 
+  const markStartingPlaybackStatusInvalid = useCallback(() => {
+    nextStartTokenRef.current++
+  }, [])
+
   const getCurrentPositionTicks = useCallback((): number => {
     const video = getActiveVideoElement()
-    const activeSession = activePlaybackStatusRef.current
+    const status = playbackStatusRef.current
+    const activeSession = status.state === 'active' ? status.session : null
     if (video !== null) {
       const currentTicks = secondsToTicks(video.currentTime)
       if (activeSession) activeSession.latestPositionTicks = currentTicks
@@ -126,17 +163,21 @@ export function useJellyfinSession({
     return activeSession?.latestPositionTicks ?? 0
   }, [getActiveVideoElement])
 
-  const consumeActivePlaybackStatus = useCallback(() => {
-    const activeSession = activePlaybackStatusRef.current
+  const consumeActiveStatus = useCallback(() => {
+    const status = playbackStatusRef.current
+    const activeSession = status.state === 'active' ? status.session : null
     const finalPositionTicks = getCurrentPositionTicks()
-    activePlaybackStatusRef.current = null
-    playbackStatusStartIdRef.current++
+    if (status.state === 'active') {
+      playbackStatusRef.current = { state: 'idle' }
+    } else if (status.state === 'starting') {
+      markStartingPlaybackStatusInvalid()
+    }
 
     return { activeSession, finalPositionTicks }
-  }, [getCurrentPositionTicks])
+  }, [getCurrentPositionTicks, markStartingPlaybackStatusInvalid])
 
   const stopPlaybackStatusReporting = useCallback(async () => {
-    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
+    const { activeSession, finalPositionTicks } = consumeActiveStatus()
     if (!activeSession) return
 
     try {
@@ -147,10 +188,11 @@ export function useJellyfinSession({
     } catch (err) {
       console.debug('Failed to stop Jellyfin playback status reporting', err)
     }
-  }, [consumeActivePlaybackStatus])
+  }, [consumeActiveStatus])
 
   const stopPlaybackStatusReportingKeepalive = useCallback(() => {
-    const { activeSession, finalPositionTicks } = consumeActivePlaybackStatus()
+    const previousStatus = playbackStatusRef.current
+    const { activeSession, finalPositionTicks } = consumeActiveStatus()
     if (activeSession) {
       stopPlaybackStatusKeepalive({
         ...activeSession,
@@ -159,77 +201,75 @@ export function useJellyfinSession({
       return
     }
 
-    const pendingSession = pendingPlaybackStatusRef.current
-    if (!pendingSession) return
+    if (previousStatus.state !== 'starting') return
 
-    pendingSession.stopQueuedWithKeepalive = true
-    pendingPlaybackStatusRef.current = null
+    previousStatus.stopQueuedWithKeepalive = true
+    playbackStatusRef.current = { state: 'idle' }
     stopPlaybackStatusKeepalive({
-      ...pendingSession.session,
+      ...previousStatus.session,
       positionTicks: Math.max(
         finalPositionTicks,
-        pendingSession.session.latestPositionTicks,
+        previousStatus.session.latestPositionTicks,
       ),
     })
-  }, [consumeActivePlaybackStatus])
+  }, [consumeActiveStatus])
 
   const startPlaybackStatusReporting = useCallback(
     async (positionTicksOverride?: number) => {
       const descriptor = currentSessionRef.current
       if (!descriptor?.syncEnabled) return
 
-      const activeSession = activePlaybackStatusRef.current
-      if (activeSession && isSameActiveSession(activeSession, descriptor)) {
+      const status = playbackStatusRef.current
+      if (status.state === 'active') {
         return
       }
 
       const video = getActiveVideoElement()
       const positionTicks =
         positionTicksOverride ?? secondsToTicks(video?.currentTime ?? 0)
-      const pendingSession = pendingPlaybackStatusRef.current
-
       if (
-        pendingSession &&
-        isSameSession(descriptor, pendingSession.descriptor)
+        status.state === 'starting' &&
+        isSameSessionDescriptor(descriptor, status.descriptor)
       ) {
-        pendingSession.startId = ++playbackStatusStartIdRef.current
-        pendingSession.session.latestPositionTicks = positionTicks
+        status.startToken = ++nextStartTokenRef.current
+        status.session.latestPositionTicks = positionTicks
         return
       }
 
-      const startId = ++playbackStatusStartIdRef.current
-      const nextSession: PendingPlaybackStatusSession = {
+      const startToken = ++nextStartTokenRef.current
+      const nextStatus: StartingPlaybackStatus = {
+        state: 'starting',
         descriptor,
         session: createActiveSession(descriptor, positionTicks),
-        startId,
+        startToken,
       }
-      pendingPlaybackStatusRef.current = nextSession
+      playbackStatusRef.current = nextStatus
 
       const isCurrentPlaybackStatusStart = () =>
-        pendingPlaybackStatusRef.current === nextSession &&
-        playbackStatusStartIdRef.current === nextSession.startId &&
-        currentSessionRef.current?.syncEnabled === true &&
-        isSameSession(currentSessionRef.current, descriptor) &&
-        !activePlaybackStatusRef.current
+        isCurrentStartingPlaybackStatus(
+          playbackStatusRef.current,
+          nextStatus,
+          currentSessionRef.current,
+          nextStartTokenRef.current,
+        )
 
       try {
         if (!isCurrentPlaybackStatusStart()) return
 
         await startPlaybackStatus({
-          itemId: nextSession.session.itemId,
-          mediaSourceId: nextSession.session.mediaSourceId,
-          playSessionId: nextSession.session.playSessionId,
-          playMethod: nextSession.session.playMethod,
-          positionTicks,
-          isPaused: video?.paused ?? true,
+          ...createPlaybackStatusPayload(
+            nextStatus.session,
+            positionTicks,
+            video?.paused ?? true,
+          ),
         })
 
         if (isCurrentPlaybackStatusStart()) {
-          activePlaybackStatusRef.current = nextSession.session
-        } else if (!nextSession.stopQueuedWithKeepalive) {
+          playbackStatusRef.current = promoteStartingPlaybackStatus(nextStatus)
+        } else if (!nextStatus.stopQueuedWithKeepalive) {
           void stopPlaybackStatus({
-            ...nextSession.session,
-            positionTicks: nextSession.session.latestPositionTicks,
+            ...nextStatus.session,
+            positionTicks: nextStatus.session.latestPositionTicks,
           }).catch((err) => {
             console.debug('Failed to stop stale Jellyfin playback status', err)
           })
@@ -237,8 +277,8 @@ export function useJellyfinSession({
       } catch (err) {
         console.debug('Failed to start Jellyfin playback status reporting', err)
       } finally {
-        if (pendingPlaybackStatusRef.current === nextSession) {
-          pendingPlaybackStatusRef.current = null
+        if (playbackStatusRef.current === nextStatus) {
+          playbackStatusRef.current = { state: 'idle' }
         }
       }
     },
@@ -272,7 +312,8 @@ export function useJellyfinSession({
 
   const reportCurrentPlaybackProgress = useEffectEvent(
     async (isPaused: boolean) => {
-      const activeSession = activePlaybackStatusRef.current
+      const status = playbackStatusRef.current
+      const activeSession = status.state === 'active' ? status.session : null
       if (!currentSessionRef.current?.syncEnabled || !activeSession) return
 
       try {

--- a/src/hooks/use-jellyfin-session.ts
+++ b/src/hooks/use-jellyfin-session.ts
@@ -163,18 +163,27 @@ export function useJellyfinSession({
     return activeSession?.latestPositionTicks ?? 0
   }, [getActiveVideoElement])
 
-  const consumeActiveStatus = useCallback(() => {
-    const status = playbackStatusRef.current
-    const activeSession = status.state === 'active' ? status.session : null
-    const finalPositionTicks = getCurrentPositionTicks()
-    if (status.state === 'active') {
-      playbackStatusRef.current = { state: 'idle' }
-    } else if (status.state === 'starting') {
-      markStartingPlaybackStatusInvalid()
-    }
+  const consumeActiveStatus = useCallback(
+    (updateStartingPosition = true) => {
+      const status = playbackStatusRef.current
+      const activeSession = status.state === 'active' ? status.session : null
+      const finalPositionTicks = getCurrentPositionTicks()
+      if (status.state === 'active') {
+        playbackStatusRef.current = { state: 'idle' }
+      } else if (status.state === 'starting') {
+        if (
+          updateStartingPosition &&
+          isSameSessionDescriptor(currentSessionRef.current, status.descriptor)
+        ) {
+          status.session.latestPositionTicks = finalPositionTicks
+        }
+        markStartingPlaybackStatusInvalid()
+      }
 
-    return { activeSession, finalPositionTicks }
-  }, [getCurrentPositionTicks, markStartingPlaybackStatusInvalid])
+      return { activeSession, finalPositionTicks }
+    },
+    [getCurrentPositionTicks, markStartingPlaybackStatusInvalid],
+  )
 
   const stopPlaybackStatusReporting = useCallback(async () => {
     const { activeSession, finalPositionTicks } = consumeActiveStatus()
@@ -192,7 +201,7 @@ export function useJellyfinSession({
 
   const stopPlaybackStatusReportingKeepalive = useCallback(() => {
     const previousStatus = playbackStatusRef.current
-    const { activeSession, finalPositionTicks } = consumeActiveStatus()
+    const { activeSession, finalPositionTicks } = consumeActiveStatus(false)
     if (activeSession) {
       stopPlaybackStatusKeepalive({
         ...activeSession,

--- a/src/hooks/use-jellyfin-session.ts
+++ b/src/hooks/use-jellyfin-session.ts
@@ -28,8 +28,6 @@ interface ActivePlaybackStatusSession {
   playMethod: PlaybackStatusPlayMethod
   latestPositionTicks: number
 }
-type StartingPlaybackStatus = Extract<PlaybackStatus, { state: 'starting' }>
-
 type PlaybackStatus =
   | { state: 'idle' }
   | {
@@ -43,6 +41,8 @@ type PlaybackStatus =
       state: 'active'
       session: ActivePlaybackStatusSession
     }
+
+type StartingPlaybackStatus = Extract<PlaybackStatus, { state: 'starting' }>
 
 interface UseJellyfinSessionOptions {
   session: JellyfinSessionDescriptor | null
@@ -92,21 +92,6 @@ function isSameSessionDescriptor(
   )
 }
 
-function createPlaybackStatusPayload(
-  session: ActivePlaybackStatusSession,
-  positionTicks: number,
-  isPaused: boolean,
-) {
-  return {
-    itemId: session.itemId,
-    mediaSourceId: session.mediaSourceId,
-    playSessionId: session.playSessionId,
-    playMethod: session.playMethod,
-    positionTicks,
-    isPaused,
-  }
-}
-
 function isCurrentStartingPlaybackStatus(
   currentStatus: PlaybackStatus,
   startingStatus: StartingPlaybackStatus,
@@ -119,15 +104,6 @@ function isCurrentStartingPlaybackStatus(
     currentDescriptor?.syncEnabled === true &&
     isSameSessionDescriptor(currentDescriptor, startingStatus.descriptor)
   )
-}
-
-function promoteStartingPlaybackStatus(
-  startingStatus: StartingPlaybackStatus,
-): PlaybackStatus {
-  return {
-    state: 'active',
-    session: startingStatus.session,
-  }
 }
 
 export function useJellyfinSession({
@@ -153,75 +129,95 @@ export function useJellyfinSession({
   const getCurrentPositionTicks = useCallback((): number => {
     const video = getActiveVideoElement()
     const status = playbackStatusRef.current
-    const activeSession = status.state === 'active' ? status.session : null
+    const sessionWithPosition =
+      status.state === 'active' || status.state === 'starting'
+        ? status.session
+        : null
     if (video !== null) {
       const currentTicks = secondsToTicks(video.currentTime)
-      if (activeSession) activeSession.latestPositionTicks = currentTicks
+      if (sessionWithPosition) {
+        sessionWithPosition.latestPositionTicks = currentTicks
+      }
       return currentTicks
     }
 
-    return activeSession?.latestPositionTicks ?? 0
+    return sessionWithPosition?.latestPositionTicks ?? 0
   }, [getActiveVideoElement])
 
-  const consumeActiveStatus = useCallback(
-    (updateStartingPosition = true) => {
-      const status = playbackStatusRef.current
-      const activeSession = status.state === 'active' ? status.session : null
-      const finalPositionTicks = getCurrentPositionTicks()
-      if (status.state === 'active') {
-        playbackStatusRef.current = { state: 'idle' }
-      } else if (status.state === 'starting') {
-        if (
-          updateStartingPosition &&
-          isSameSessionDescriptor(currentSessionRef.current, status.descriptor)
-        ) {
-          status.session.latestPositionTicks = finalPositionTicks
-        }
-        markStartingPlaybackStatusInvalid()
-      }
+  const consumeActivePlaybackStatus = useCallback(() => {
+    const status = playbackStatusRef.current
+    if (status.state !== 'active') return null
 
-      return { activeSession, finalPositionTicks }
-    },
-    [getCurrentPositionTicks, markStartingPlaybackStatusInvalid],
-  )
+    const finalPositionTicks = getCurrentPositionTicks()
+    playbackStatusRef.current = { state: 'idle' }
+
+    return { activeSession: status.session, finalPositionTicks }
+  }, [getCurrentPositionTicks])
+
+  const invalidateStartingPlaybackStatus = useCallback(() => {
+    const status = playbackStatusRef.current
+    if (status.state !== 'starting') return
+
+    if (isSameSessionDescriptor(currentSessionRef.current, status.descriptor)) {
+      status.session.latestPositionTicks = getCurrentPositionTicks()
+    }
+    markStartingPlaybackStatusInvalid()
+  }, [getCurrentPositionTicks, markStartingPlaybackStatusInvalid])
+
+  const queueStartingPlaybackStatusKeepaliveStop = useCallback(() => {
+    const status = playbackStatusRef.current
+    if (status.state !== 'starting') return null
+
+    const latestPositionTicks = status.session.latestPositionTicks
+    const currentPositionTicks = isSameSessionDescriptor(
+      currentSessionRef.current,
+      status.descriptor,
+    )
+      ? getCurrentPositionTicks()
+      : latestPositionTicks
+    const finalPositionTicks = Math.max(currentPositionTicks, latestPositionTicks)
+    status.stopQueuedWithKeepalive = true
+    playbackStatusRef.current = { state: 'idle' }
+    markStartingPlaybackStatusInvalid()
+
+    return { session: status.session, finalPositionTicks }
+  }, [getCurrentPositionTicks, markStartingPlaybackStatusInvalid])
 
   const stopPlaybackStatusReporting = useCallback(async () => {
-    const { activeSession, finalPositionTicks } = consumeActiveStatus()
-    if (!activeSession) return
+    const activeStatus = consumeActivePlaybackStatus()
+    if (!activeStatus) {
+      invalidateStartingPlaybackStatus()
+      return
+    }
 
     try {
       await stopPlaybackStatus({
-        ...activeSession,
-        positionTicks: finalPositionTicks,
+        ...activeStatus.activeSession,
+        positionTicks: activeStatus.finalPositionTicks,
       })
     } catch (err) {
       console.debug('Failed to stop Jellyfin playback status reporting', err)
     }
-  }, [consumeActiveStatus])
+  }, [consumeActivePlaybackStatus, invalidateStartingPlaybackStatus])
 
   const stopPlaybackStatusReportingKeepalive = useCallback(() => {
-    const previousStatus = playbackStatusRef.current
-    const { activeSession, finalPositionTicks } = consumeActiveStatus(false)
-    if (activeSession) {
+    const activeStatus = consumeActivePlaybackStatus()
+    if (activeStatus) {
       stopPlaybackStatusKeepalive({
-        ...activeSession,
-        positionTicks: finalPositionTicks,
+        ...activeStatus.activeSession,
+        positionTicks: activeStatus.finalPositionTicks,
       })
       return
     }
 
-    if (previousStatus.state !== 'starting') return
+    const startingStatus = queueStartingPlaybackStatusKeepaliveStop()
+    if (!startingStatus) return
 
-    previousStatus.stopQueuedWithKeepalive = true
-    playbackStatusRef.current = { state: 'idle' }
     stopPlaybackStatusKeepalive({
-      ...previousStatus.session,
-      positionTicks: Math.max(
-        finalPositionTicks,
-        previousStatus.session.latestPositionTicks,
-      ),
+      ...startingStatus.session,
+      positionTicks: startingStatus.finalPositionTicks,
     })
-  }, [consumeActiveStatus])
+  }, [consumeActivePlaybackStatus, queueStartingPlaybackStatusKeepaliveStop])
 
   const startPlaybackStatusReporting = useCallback(
     async (positionTicksOverride?: number) => {
@@ -266,15 +262,19 @@ export function useJellyfinSession({
         if (!isCurrentPlaybackStatusStart()) return
 
         await startPlaybackStatus({
-          ...createPlaybackStatusPayload(
-            nextStatus.session,
-            positionTicks,
-            video?.paused ?? true,
-          ),
+          itemId: nextStatus.session.itemId,
+          mediaSourceId: nextStatus.session.mediaSourceId,
+          playSessionId: nextStatus.session.playSessionId,
+          playMethod: nextStatus.session.playMethod,
+          positionTicks,
+          isPaused: video?.paused ?? true,
         })
 
         if (isCurrentPlaybackStatusStart()) {
-          playbackStatusRef.current = promoteStartingPlaybackStatus(nextStatus)
+          playbackStatusRef.current = {
+            state: 'active',
+            session: nextStatus.session,
+          }
         } else if (!nextStatus.stopQueuedWithKeepalive) {
           void stopPlaybackStatus({
             ...nextStatus.session,

--- a/src/hooks/use-jellyfin-session.ts
+++ b/src/hooks/use-jellyfin-session.ts
@@ -184,7 +184,10 @@ export function useJellyfinSession({
     )
       ? getCurrentPositionTicks()
       : latestPositionTicks
-    const finalPositionTicks = Math.max(currentPositionTicks, latestPositionTicks)
+    const finalPositionTicks = Math.max(
+      currentPositionTicks,
+      latestPositionTicks,
+    )
     status.stopQueuedWithKeepalive = true
     playbackStatusRef.current = { state: 'idle' }
     markStartingPlaybackStatusInvalid()

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -58,7 +58,9 @@ interface UseVideoPlayerReturn {
 }
 
 type JellyfinSessionIdentity = Omit<JellyfinSessionDescriptor, 'syncEnabled'>
-interface PendingPlaybackStatusStart {
+// Waits for React to commit the new session descriptor before calling
+// jellyfin.startPlaybackStatus(positionTicksOverride).
+interface PostCommitPlaybackStatusStart {
   positionTicksOverride?: number
 }
 
@@ -139,8 +141,8 @@ export function useVideoPlayer({
   const currentStrategyRef = useRef<PlaybackStrategy>('hls')
   /** Guards against error handler firing during intentional strategy switches (e.g. audio track switch) */
   const intentionalSwitchRef = useRef(false)
-  const pendingPlaybackStatusStartRef =
-    useRef<PendingPlaybackStatusStart | null>(null)
+  const pendingPostCommitStartRef =
+    useRef<PostCommitPlaybackStatusStart | null>(null)
 
   const preservation = usePlaybackStatePreservation()
 
@@ -211,27 +213,24 @@ export function useVideoPlayer({
     getActiveVideoElement,
   })
 
-  const clearQueuedPlaybackStatusStart = useCallback(() => {
-    pendingPlaybackStatusStartRef.current = null
+  const clearPostCommitStart = useCallback(() => {
+    pendingPostCommitStartRef.current = null
   }, [])
 
-  const queuePlaybackStatusStart = useCallback(
-    (positionTicksOverride?: number) => {
-      pendingPlaybackStatusStartRef.current = { positionTicksOverride }
-    },
-    [],
-  )
+  const queuePostCommitStart = useCallback((positionTicksOverride?: number) => {
+    pendingPostCommitStartRef.current = { positionTicksOverride }
+  }, [])
 
-  const startQueuedPlaybackStatus = useEffectEvent(() => {
-    const pendingStart = pendingPlaybackStatusStartRef.current
-    if (!pendingStart) return
+  const flushPostCommitStart = useEffectEvent(() => {
+    const postCommitStart = pendingPostCommitStartRef.current
+    if (!postCommitStart) return
 
-    pendingPlaybackStatusStartRef.current = null
-    void jellyfin.startPlaybackStatus(pendingStart.positionTicksOverride)
+    pendingPostCommitStartRef.current = null
+    void jellyfin.startPlaybackStatus(postCommitStart.positionTicksOverride)
   })
 
   useEffect(() => {
-    startQueuedPlaybackStatus()
+    flushPostCommitStart()
   }, [jellyfinSession])
 
   const switchToHls = useCallback(
@@ -282,7 +281,7 @@ export function useVideoPlayer({
             ),
           )
           preservation.scheduleHlsRestore(hlsPlayer.videoRef, itemId)
-          queuePlaybackStatusStart(directPositionTicks)
+          queuePostCommitStart(directPositionTicks)
         }
       }
     },
@@ -292,7 +291,7 @@ export function useVideoPlayer({
       preservation,
       hlsPlayer.videoRef,
       jellyfin,
-      queuePlaybackStatusStart,
+      queuePostCommitStart,
       updateStrategy,
     ],
   )
@@ -388,7 +387,7 @@ export function useVideoPlayer({
   // from the playback init path; widening these dependencies starts duplicate sessions.
   const syncPlaybackStatus = useEffectEvent(() => {
     if (!jellyfinPlaybackSyncEnabled) {
-      clearQueuedPlaybackStatusStart()
+      clearPostCommitStart()
       void jellyfin.stopPlaybackStatus()
       return
     }
@@ -413,7 +412,7 @@ export function useVideoPlayer({
     isActiveRef.current = true
     networkRetryCountRef.current = 0
     intentionalSwitchRef.current = false
-    clearQueuedPlaybackStatusStart()
+    clearPostCommitStart()
     preservation.clearHlsRestoreSubscription()
 
     const initPlayback = async () => {
@@ -443,7 +442,7 @@ export function useVideoPlayer({
             ),
           )
           handleInitPlaybackSuccess(config, itemId)
-          queuePlaybackStatusStart()
+          queuePostCommitStart()
         }
       } catch (err) {
         if (playbackRequestIdRef.current !== requestId) return
@@ -470,7 +469,7 @@ export function useVideoPlayer({
         requestId + 1,
       )
       intentionalSwitchRef.current = false
-      clearQueuedPlaybackStatusStart()
+      clearPostCommitStart()
       preservation.clearHlsRestoreSubscription()
       void jellyfin.stopPlaybackStatus()
     }
@@ -481,8 +480,8 @@ export function useVideoPlayer({
     getActiveVideoElement,
     jellyfin,
     preservation,
-    clearQueuedPlaybackStatusStart,
-    queuePlaybackStatusStart,
+    clearPostCommitStart,
+    queuePostCommitStart,
   ])
 
   useEffect(() => {
@@ -584,7 +583,7 @@ export function useVideoPlayer({
       )
       setVideoUrl(url)
       preservation.scheduleHlsRestore(hlsPlayer.videoRef, itemId)
-      queuePlaybackStatusStart(activePositionTicks)
+      queuePostCommitStart(activePositionTicks)
     },
     [
       itemId,
@@ -594,7 +593,7 @@ export function useVideoPlayer({
       jellyfin,
       jellyfinSessionIdentity,
       preservation,
-      queuePlaybackStatusStart,
+      queuePostCommitStart,
       updateStrategy,
     ],
   )


### PR DESCRIPTION
## Summary by Sourcery

Refine Jellyfin playback status lifecycle handling to better preserve playback position across strategy changes, pending sessions, and keepalive flows.

Bug Fixes:
- Ensure playback position is preserved when direct play fails over to HLS and when sync is disabled or sessions change while starts/stops are pending.
- Retain the last known playback position when stopping playback status without an attached video element and when handling stale keepalive stops after an item change.

Enhancements:
- Refactor Jellyfin playback status management into an explicit state machine with idle, starting, and active states to robustly handle race conditions and session changes.
- Rename and clarify deferred playback-start handling in the video player hook to run starts only after React has committed the new session, improving correctness during strategy switches.

Tests:
- Add and update playback sync tests to cover direct-to-HLS fallback, pending stop without a video element, updated positions when sync is disabled mid-start, and stale keepalive handling across item changes.