### PR TITLE
Add Vite preload error handler and preloads

### DIFF
--- a/src/__tests__/vite-preload-error.test.ts
+++ b/src/__tests__/vite-preload-error.test.ts
@@ -154,13 +154,15 @@ describe('vite preload error handling', () => {
     reload.mockClear()
 
     const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    const addEventListener = vi.fn()
+    const removeEventListener = vi.fn()
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
       value: {
         location: { href, reload },
         sessionStorage: storage,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
+        addEventListener,
+        removeEventListener,
         setTimeout: globalThis.setTimeout,
         clearTimeout: globalThis.clearTimeout,
       },
@@ -168,6 +170,12 @@ describe('vite preload error handling', () => {
 
     try {
       const uninstall = installVitePreloadErrorHandler()
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+      expect(addEventListener).toHaveBeenCalledWith(
+        'vite:preloadError',
+        expect.any(Function),
+      )
+      const registeredHandler = addEventListener.mock.calls[0]?.[1]
 
       vi.advanceTimersByTime(5_000)
 
@@ -182,6 +190,11 @@ describe('vite preload error handling', () => {
       expect(reload).toHaveBeenCalledTimes(1)
 
       uninstall()
+      expect(removeEventListener).toHaveBeenCalledTimes(1)
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'vite:preloadError',
+        registeredHandler,
+      )
     } finally {
       if (originalWindow) {
         Object.defineProperty(globalThis, 'window', originalWindow)
@@ -209,13 +222,15 @@ describe('vite preload error handling', () => {
 
     const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
     const location = { href: recoveredHref, reload }
+    const addEventListener = vi.fn()
+    const removeEventListener = vi.fn()
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
       value: {
         location,
         sessionStorage: storage,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
+        addEventListener,
+        removeEventListener,
         setTimeout: globalThis.setTimeout,
         clearTimeout: globalThis.clearTimeout,
       },
@@ -223,6 +238,13 @@ describe('vite preload error handling', () => {
 
     try {
       const uninstall = installVitePreloadErrorHandler()
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+      expect(addEventListener).toHaveBeenCalledWith(
+        'vite:preloadError',
+        expect.any(Function),
+      )
+      const registeredHandler = addEventListener.mock.calls[0]?.[1]
+
       location.href = navigatedHref
 
       vi.advanceTimersByTime(5_000)
@@ -238,6 +260,11 @@ describe('vite preload error handling', () => {
       expect(reload).toHaveBeenCalledTimes(1)
 
       uninstall()
+      expect(removeEventListener).toHaveBeenCalledTimes(1)
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'vite:preloadError',
+        registeredHandler,
+      )
     } finally {
       if (originalWindow) {
         Object.defineProperty(globalThis, 'window', originalWindow)

--- a/src/__tests__/vite-preload-error.test.ts
+++ b/src/__tests__/vite-preload-error.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createVitePreloadErrorHandler,
+  installVitePreloadErrorHandler,
+} from '@/lib/vite-preload-error'
+
+function createStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> {
+  const values: Record<string, string> = {}
+
+  return {
+    getItem: vi.fn((key: string) => values[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      values[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete values[key]
+    }),
+  }
+}
+
+function createPreloadEvent(): VitePreloadErrorEvent {
+  return {
+    payload: new Error('Failed to fetch dynamically imported module'),
+    preventDefault: vi.fn(),
+  } as unknown as VitePreloadErrorEvent
+}
+
+describe('vite preload error handling', () => {
+  it('reloads the current page once for the first preload error', () => {
+    const href =
+      'https://segment-editor.test/player/00000000-0000-0000-0000-000000000001'
+    const reload = vi.fn()
+    const storage = createStorage()
+    const handler = createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })
+    const event = createPreloadEvent()
+
+    handler(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(storage.setItem).toHaveBeenCalledWith(expect.any(String), href)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses duplicate preload errors while a reload is pending', () => {
+    const href = 'https://segment-editor.test/'
+    const reload = vi.fn()
+    const storage = createStorage()
+    const handler = createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })
+
+    handler(createPreloadEvent())
+    reload.mockClear()
+
+    const duplicateEvent = createPreloadEvent()
+    handler(duplicateEvent)
+
+    expect(duplicateEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('lets the import error propagate after a reload already failed for this URL', () => {
+    const href =
+      'https://segment-editor.test/album/00000000-0000-0000-0000-000000000001'
+    const reload = vi.fn()
+    const storage = createStorage()
+
+    createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })(createPreloadEvent())
+
+    const eventAfterReload = createPreloadEvent()
+    createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })(eventAfterReload)
+
+    expect(eventAfterReload.preventDefault).not.toHaveBeenCalled()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets the import error propagate when session storage is unavailable', () => {
+    const href = 'https://segment-editor.test/'
+    const reload = vi.fn()
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: Object.defineProperty({}, 'sessionStorage', {
+        configurable: true,
+        get: () => {
+          throw new Error('Storage access denied')
+        },
+      }),
+    })
+
+    try {
+      const handler = createVitePreloadErrorHandler({
+        location: { href, reload },
+      })
+      const event = createPreloadEvent()
+
+      handler(event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(reload).not.toHaveBeenCalled()
+    } finally {
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow)
+      } else {
+        delete (globalThis as { window?: unknown }).window
+      }
+    }
+  })
+
+  it('lets the import error propagate when the reload marker cannot persist', () => {
+    const href = 'https://segment-editor.test/'
+    const reload = vi.fn()
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(() => {
+        throw new Error('Storage write denied')
+      }),
+      removeItem: vi.fn(),
+    }
+    const handler = createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })
+    const event = createPreloadEvent()
+
+    handler(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('clears the reload marker after startup remains stable', () => {
+    vi.useFakeTimers()
+
+    const href = 'https://segment-editor.test/'
+    const reload = vi.fn()
+    const storage = createStorage()
+
+    createVitePreloadErrorHandler({
+      location: { href, reload },
+      storage,
+    })(createPreloadEvent())
+    reload.mockClear()
+
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: { href, reload },
+        sessionStorage: storage,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        setTimeout: globalThis.setTimeout,
+        clearTimeout: globalThis.clearTimeout,
+      },
+    })
+
+    try {
+      const uninstall = installVitePreloadErrorHandler()
+
+      vi.advanceTimersByTime(5_000)
+
+      const eventAfterStableStartup = createPreloadEvent()
+      createVitePreloadErrorHandler({
+        location: { href, reload },
+        storage,
+      })(eventAfterStableStartup)
+
+      expect(storage.removeItem).toHaveBeenCalledWith(expect.any(String))
+      expect(eventAfterStableStartup.preventDefault).toHaveBeenCalledTimes(1)
+      expect(reload).toHaveBeenCalledTimes(1)
+
+      uninstall()
+    } finally {
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow)
+      } else {
+        delete (globalThis as { window?: unknown }).window
+      }
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears the reload marker for the recovered URL after client-side navigation', () => {
+    vi.useFakeTimers()
+
+    const recoveredHref =
+      'https://segment-editor.test/player/00000000-0000-0000-0000-000000000001'
+    const navigatedHref = 'https://segment-editor.test/'
+    const reload = vi.fn()
+    const storage = createStorage()
+
+    createVitePreloadErrorHandler({
+      location: { href: recoveredHref, reload },
+      storage,
+    })(createPreloadEvent())
+    reload.mockClear()
+
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    const location = { href: recoveredHref, reload }
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location,
+        sessionStorage: storage,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        setTimeout: globalThis.setTimeout,
+        clearTimeout: globalThis.clearTimeout,
+      },
+    })
+
+    try {
+      const uninstall = installVitePreloadErrorHandler()
+      location.href = navigatedHref
+
+      vi.advanceTimersByTime(5_000)
+
+      const eventAfterStableStartup = createPreloadEvent()
+      createVitePreloadErrorHandler({
+        location: { href: recoveredHref, reload },
+        storage,
+      })(eventAfterStableStartup)
+
+      expect(storage.removeItem).toHaveBeenCalledWith(expect.any(String))
+      expect(eventAfterStableStartup.preventDefault).toHaveBeenCalledTimes(1)
+      expect(reload).toHaveBeenCalledTimes(1)
+
+      uninstall()
+    } finally {
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow)
+      } else {
+        delete (globalThis as { window?: unknown }).window
+      }
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,6 +32,16 @@ const loadCommandPalette = () => import('@/components/header/CommandPalette')
 const loadEpisodeSwitcher = () => import('@/components/header/EpisodeSwitcher')
 const loadSettingsDialog = () => import('@/components/settings')
 
+const ignorePreloadError = () => undefined
+
+const preloadCommandPalette = () => {
+  void loadCommandPalette().catch(ignorePreloadError)
+}
+
+const preloadSettingsDialog = () => {
+  void loadSettingsDialog().catch(ignorePreloadError)
+}
+
 const CommandPalette = lazy(() =>
   loadCommandPalette().then((module) => ({
     default: module.CommandPalette,
@@ -122,6 +132,11 @@ export default function Header() {
 
   const toggleSettings = useSessionStore((s) => s.toggleSettings)
 
+  const handleSettingsClick = () => {
+    preloadSettingsDialog()
+    toggleSettings()
+  }
+
   const handleCollectionSelect = (collectionId: string | null) => {
     void navigate({
       to: '/',
@@ -162,7 +177,7 @@ export default function Header() {
 
   // Keyboard shortcuts for command palette
   const openCommandPalette = () => {
-    void loadCommandPalette()
+    preloadCommandPalette()
     setCommandPaletteOpen(true)
   }
 
@@ -279,12 +294,8 @@ export default function Header() {
                   variant="ghost"
                   size="icon"
                   onClick={() => setCommandPaletteOpen(true)}
-                  onPointerEnter={() => {
-                    void loadCommandPalette()
-                  }}
-                  onFocus={() => {
-                    void loadCommandPalette()
-                  }}
+                  onPointerEnter={preloadCommandPalette}
+                  onFocus={preloadCommandPalette}
                   className={cn(
                     iconButtonClass,
                     !vibrantColors && 'bg-secondary/60 hover:bg-secondary',
@@ -319,13 +330,9 @@ export default function Header() {
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={toggleSettings}
-                onPointerEnter={() => {
-                  void loadSettingsDialog()
-                }}
-                onFocus={() => {
-                  void loadSettingsDialog()
-                }}
+                onClick={handleSettingsClick}
+                onPointerEnter={preloadSettingsDialog}
+                onFocus={preloadSettingsDialog}
                 className={cn(
                   iconButtonClass,
                   !vibrantColors && 'bg-secondary/60 hover:bg-secondary',

--- a/src/lib/vite-preload-error.ts
+++ b/src/lib/vite-preload-error.ts
@@ -1,0 +1,81 @@
+const PRELOAD_RELOAD_URL_KEY = 'segment-editor:vite-preload-error-url'
+const RELOAD_MARKER_CLEAR_DELAY_MS = 5_000
+
+type VitePreloadErrorStorage = Pick<
+  Storage,
+  'getItem' | 'setItem' | 'removeItem'
+>
+
+function getSessionStorage(): VitePreloadErrorStorage | undefined {
+  try {
+    return window.sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+export interface VitePreloadErrorHandlerOptions {
+  location?: Pick<Location, 'href' | 'reload'>
+  storage?: VitePreloadErrorStorage
+}
+
+export function createVitePreloadErrorHandler(
+  options: VitePreloadErrorHandlerOptions = {},
+): (event: VitePreloadErrorEvent) => void {
+  const location = options.location ?? window.location
+  const storage = options.storage ?? getSessionStorage()
+  let reloadPending = false
+
+  return (event: VitePreloadErrorEvent) => {
+    if (reloadPending) {
+      event.preventDefault()
+      return
+    }
+
+    if (storage === undefined) return
+
+    try {
+      if (storage.getItem(PRELOAD_RELOAD_URL_KEY) === location.href) return
+      storage.setItem(PRELOAD_RELOAD_URL_KEY, location.href)
+    } catch {
+      return
+    }
+
+    reloadPending = true
+    event.preventDefault()
+    location.reload()
+  }
+}
+
+function clearPreloadReloadMarker(
+  href: string,
+  storage: VitePreloadErrorStorage,
+) {
+  try {
+    if (storage.getItem(PRELOAD_RELOAD_URL_KEY) === href) {
+      storage.removeItem(PRELOAD_RELOAD_URL_KEY)
+    }
+  } catch {}
+}
+
+export function installVitePreloadErrorHandler(): () => void {
+  const location = window.location
+  const startupHref = location.href
+  const storage = getSessionStorage()
+  const handler = createVitePreloadErrorHandler({ location, storage })
+  const markerClearTimer =
+    storage === undefined
+      ? undefined
+      : window.setTimeout(() => {
+          clearPreloadReloadMarker(startupHref, storage)
+        }, RELOAD_MARKER_CLEAR_DELAY_MS)
+
+  window.addEventListener('vite:preloadError', handler)
+
+  return () => {
+    window.removeEventListener('vite:preloadError', handler)
+    if (markerClearTimer !== undefined) {
+      window.clearTimeout(markerClearTimer)
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,8 +27,11 @@ import {
   isPluginMode,
 } from './services/jellyfin/core'
 import { DesktopFallback } from './components/DesktopFallback'
+import { installVitePreloadErrorHandler } from './lib/vite-preload-error'
 
 import './styles.css'
+
+installVitePreloadErrorHandler()
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/routes/-root-components.tsx
+++ b/src/routes/-root-components.tsx
@@ -24,22 +24,27 @@ import { registerPwaUpdates } from '../lib/pwa'
 import { isPluginMode } from '../services/jellyfin/core'
 import { useSessionStore } from '../stores/session-store'
 
+const loadDevTools = () => import('../components/DevTools')
+const loadSettingsDialog = () => import('../components/settings')
+const loadConnectionWizard = () =>
+  import('../components/connection/ConnectionWizard')
+
 const DevTools = import.meta.env.DEV
   ? lazy(() =>
-      import('../components/DevTools').then((module) => ({
+      loadDevTools().then((module) => ({
         default: module.DevTools,
       })),
     )
   : null
 
 const SettingsDialog = lazy(() =>
-  import('../components/settings').then((module) => ({
+  loadSettingsDialog().then((module) => ({
     default: module.SettingsDialog,
   })),
 )
 
 const ConnectionWizard = lazy(() =>
-  import('../components/connection/ConnectionWizard').then((module) => ({
+  loadConnectionWizard().then((module) => ({
     default: module.ConnectionWizard,
   })),
 )

--- a/src/routes/album/$itemId.tsx
+++ b/src/routes/album/$itemId.tsx
@@ -35,6 +35,7 @@ export const Route = createFileRoute('/album/$itemId')({
     const [album] = await Promise.all([
       queryClient.ensureQueryData(itemsQueryOptions.detail(itemId)),
       queryClient.ensureQueryData(albumQueryOptions.tracks(itemId)),
+      import('@/components/views/AlbumView'),
     ])
     assertItemFound(album, abortController.signal)
   },

--- a/src/routes/artist/$itemId.tsx
+++ b/src/routes/artist/$itemId.tsx
@@ -35,6 +35,7 @@ export const Route = createFileRoute('/artist/$itemId')({
     const [artist] = await Promise.all([
       queryClient.ensureQueryData(itemsQueryOptions.detail(itemId)),
       queryClient.ensureQueryData(artistQueryOptions.albums(itemId)),
+      import('@/components/views/ArtistView'),
     ])
     assertItemFound(artist, abortController.signal)
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -50,8 +50,8 @@ function IndexSkeleton() {
 
 export const Route = createFileRoute('/')({
   component: IndexPage,
-  loader: async () => {
-    await loadFilterView()
+  loader: () => {
+    void loadFilterView().catch(() => undefined)
   },
   validateSearch: indexSearchSchema,
   pendingComponent: IndexSkeleton,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,8 +15,9 @@ import { z } from 'zod'
 import { FeatureErrorBoundary } from '@/components/ui/feature-error-boundary'
 import { MediaGridSkeleton } from '@/components/ui/loading-skeleton'
 
+const loadFilterView = () => import('@/components/filter/FilterView')
 const FilterView = lazy(() =>
-  import('@/components/filter/FilterView').then((module) => ({
+  loadFilterView().then((module) => ({
     default: module.FilterView,
   })),
 )
@@ -49,6 +50,9 @@ function IndexSkeleton() {
 
 export const Route = createFileRoute('/')({
   component: IndexPage,
+  loader: async () => {
+    await loadFilterView()
+  },
   validateSearch: indexSearchSchema,
   pendingComponent: IndexSkeleton,
 })

--- a/src/routes/player/$itemId.tsx
+++ b/src/routes/player/$itemId.tsx
@@ -50,13 +50,15 @@ export const Route = createFileRoute('/player/$itemId')({
       ? queryClient.ensureQueryData(segmentsQueryOptions.list(itemId))
       : undefined
     void segmentsPromise?.catch(() => undefined)
+    const playerEditorModulePromise = import('@/components/player/PlayerEditor')
+    void playerEditorModulePromise.catch(() => undefined)
 
     const item = await queryClient.ensureQueryData(
       itemsQueryOptions.detail(itemId),
     )
     assertItemFound(item, abortController.signal)
 
-    await segmentsPromise
+    await Promise.all([segmentsPromise, playerEditorModulePromise])
   },
   errorComponent: DetailRouteErrorComponent,
   pendingComponent: PlayerSkeleton,

--- a/src/routes/series/$itemId.tsx
+++ b/src/routes/series/$itemId.tsx
@@ -40,6 +40,7 @@ export const Route = createFileRoute('/series/$itemId')({
     const [series] = await Promise.all([
       queryClient.ensureQueryData(itemsQueryOptions.detail(itemId)),
       queryClient.ensureQueryData(seriesQueryOptions.seasons(itemId)),
+      import('@/components/views/SeriesView'),
     ])
     assertItemFound(series, abortController.signal)
   },


### PR DESCRIPTION
## Summary by Sourcery

Introduce centralized handling for Vite preload errors and proactively preload key lazily loaded UI components to improve resilience and perceived performance.

New Features:
- Add a Vite preload error handler that reloads the page once on preload failures while avoiding reload loops.
- Install global Vite preload error handling in the application bootstrap to listen for Vite preload error events.
- Proactively preload command palette, settings dialog, filter view, player editor, and media view components during relevant user interactions or route loading.

Enhancements:
- Refine lazy-loading entry points by extracting reusable dynamic import helpers for shared components.

Tests:
- Add unit tests covering Vite preload error handling behavior, including storage availability, reload suppression, and recovery marker cleanup.