### PR TITLE
Fix native audio track language matching for unknown empty languages

### DIFF
--- a/src/__tests__/track-switching.test.ts
+++ b/src/__tests__/track-switching.test.ts
@@ -153,6 +153,31 @@ describe('switchAudioTrack native and HLS runtime selection', () => {
     expect(onReloadHls).not.toHaveBeenCalled()
   })
 
+  it('skips a native audio track with unknown language when matching by language', async () => {
+    const video = document.createElement('video')
+    // The HTML AudioTrack API reports an empty language string when unknown; it
+    // must not match every requested language and shadow the real match.
+    const { list, tracks } = createNativeAudioTracks(['', 'jpn'])
+    Object.defineProperty(video, 'audioTracks', {
+      configurable: true,
+      value: list,
+    })
+    const onReloadHls = vi.fn<() => Promise<void>>()
+
+    await expect(
+      switchAudioTrack(7, {
+        strategy: 'direct',
+        videoElement: video,
+        audioTracks: [createAudioTrack(5, 0, 'eng'), createAudioTrack(7, 99, 'jpn')],
+        itemId: 'item-native',
+        onReloadHls,
+      }),
+    ).resolves.toEqual({ success: true })
+
+    expect(tracks.map((track) => track.enabled)).toEqual([false, true])
+    expect(onReloadHls).not.toHaveBeenCalled()
+  })
+
   it('falls back to HLS reload when no native audio track matches', async () => {
     createPlaySessionIdMock.mockReturnValue('play-session-1')
     getVideoStreamUrlMock.mockReturnValue('https://example.com/hls.m3u8')

--- a/src/services/video/track-switching.ts
+++ b/src/services/video/track-switching.ts
@@ -259,8 +259,9 @@ function nativeAudioTrackLanguageMatches(
   // A track whose language is unknown (the HTML AudioTrack API reports an empty
   // string) must not match every requested language. Bail out before the prefix
   // comparisons below, where slicing "" produces a wildcard prefix that
-  // startsWith() always matches.
-  if (!targetLang || !nativeLang) {
+  // startsWith() always matches. An empty target language is already rejected by
+  // the prefix-length guard further down, so only the native side needs this.
+  if (!nativeLang) {
     return false
   }
 

--- a/src/services/video/track-switching.ts
+++ b/src/services/video/track-switching.ts
@@ -255,10 +255,29 @@ function nativeAudioTrackLanguageMatches(
 ): boolean {
   const targetLang = targetLanguage.toLowerCase()
   const nativeLang = nativeLanguage.toLowerCase()
+
+  // A track whose language is unknown (the HTML AudioTrack API reports an empty
+  // string) must not match every requested language. Bail out before the prefix
+  // comparisons below, where slicing "" produces a wildcard prefix that
+  // startsWith() always matches.
+  if (!targetLang || !nativeLang) {
+    return false
+  }
+
+  if (nativeLang === targetLang) {
+    return true
+  }
+
+  // Compare ISO language prefixes, but only when both prefixes are at least two
+  // characters so a one-character code cannot collapse into a wildcard prefix.
+  const targetPrefix = targetLang.slice(0, 2)
+  const nativePrefix = nativeLang.slice(0, 2)
+  if (targetPrefix.length < 2 || nativePrefix.length < 2) {
+    return false
+  }
+
   return (
-    nativeLang === targetLang ||
-    nativeLang.startsWith(targetLang.slice(0, 2)) ||
-    targetLang.startsWith(nativeLang.slice(0, 2))
+    nativeLang.startsWith(targetPrefix) || targetLang.startsWith(nativePrefix)
   )
 }
 


### PR DESCRIPTION
Fix native audio track language matching to skip tracks with unknown language instead of treating the empty string as a wildcard prefix. The HTML AudioTrack API reports `""` for tracks without a language tag, which the previous implementation would match against any requested language via prefix-matching logic, causing the wrong track to be selected.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/2df99218-a87c-49cf-a0c1-bebb3e93dbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-046" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/2df99218-a87c-49cf-a0c1-bebb3e93dbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-046&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-046"><img alt="INTRO-046" src="https://capy.ai/api/badge/thread.svg?label=INTRO-046"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Fix language-based native audio track selection to ignore tracks with unknown or invalid language codes.

Bug Fixes:
- Prevent native audio tracks with empty or unknown language codes from matching all requested languages during selection.

Tests:
- Add regression test verifying that native audio tracks with unknown language are skipped in favor of correctly tagged tracks when matching by language.