### PR TITLE
Compat and protection for a missing cancelIdleCallback

### DIFF
--- a/src/__tests__/idle-task.test.ts
+++ b/src/__tests__/idle-task.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { scheduleIdleTask } from '@/lib/idle-task'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('scheduleIdleTask', () => {
+  it('uses requestIdleCallback when available', () => {
+    const task = vi.fn()
+    const requestIdleCallback = vi.fn(() => 42)
+    const cancelIdleCallback = vi.fn()
+
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback)
+    vi.stubGlobal('cancelIdleCallback', cancelIdleCallback)
+
+    const cancel = scheduleIdleTask(task, {
+      timeout: 180,
+      fallbackDelay: 100,
+    })
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 180,
+    })
+
+    cancel()
+    cancel()
+
+    expect(cancelIdleCallback).toHaveBeenCalledOnce()
+    expect(cancelIdleCallback).toHaveBeenCalledWith(42)
+  })
+
+  it('falls back to a timer when requestIdleCallback is unavailable', () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    const task = vi.fn()
+
+    scheduleIdleTask(task, {
+      timeout: 180,
+      fallbackDelay: 100,
+    })
+
+    vi.advanceTimersByTime(99)
+    expect(task).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(task).toHaveBeenCalledOnce()
+  })
+
+  it('prevents a cancelled task from running without a native cancel API', () => {
+    let scheduledTask: (() => void) | undefined
+    vi.stubGlobal(
+      'requestIdleCallback',
+      vi.fn((callback: () => void) => {
+        scheduledTask = callback
+        return 7
+      }),
+    )
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    const task = vi.fn()
+
+    const cancel = scheduleIdleTask(task, {
+      timeout: 180,
+      fallbackDelay: 100,
+    })
+
+    cancel()
+    scheduledTask?.()
+
+    expect(task).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/filter/FilterView.tsx
+++ b/src/components/filter/FilterView.tsx
@@ -31,6 +31,7 @@ import { usePluginMode } from '@/hooks/use-connection-init'
 import { useGridKeyboardNavigation } from '@/hooks/use-grid-keyboard-navigation'
 import { useVirtualWindow } from '@/hooks/use-virtual-window'
 import { preloadVibrantColors } from '@/hooks/use-vibrant-color'
+import { scheduleIdleTask } from '@/lib/idle-task'
 import { MediaCard } from '@/components/filter/MediaCard'
 import { MediaListRow } from '@/components/filter/MediaListRow'
 import { MediaListSkeleton } from '@/components/filter/MediaListSkeleton'
@@ -249,25 +250,10 @@ function useRenderFilterView() {
       }
     }
 
-    let timeoutId: number | null = null
-    let idleId: number | null = null
-
-    if (typeof window.requestIdleCallback === 'function') {
-      idleId = window.requestIdleCallback(preloadVisibleColors, {
-        timeout: 250,
-      })
-    } else {
-      timeoutId = window.setTimeout(preloadVisibleColors, 100)
-    }
-
-    return () => {
-      if (idleId !== null && typeof window.cancelIdleCallback === 'function') {
-        window.cancelIdleCallback(idleId)
-      }
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId)
-      }
-    }
+    return scheduleIdleTask(preloadVisibleColors, {
+      timeout: 250,
+      fallbackDelay: 100,
+    })
   }, [paginatedItems, columns])
 
   const handleCollectionChange = (value: string | null) => {

--- a/src/components/media/ItemImage.tsx
+++ b/src/components/media/ItemImage.tsx
@@ -4,6 +4,7 @@ import { decode } from 'blurhash'
 import type { BaseItemDto } from '@/types/jellyfin'
 import { getBestImageUrl, getImageBlurhash } from '@/services/video/api'
 import { useBlobUrl } from '@/hooks/useBlobUrl'
+import { scheduleIdleTask } from '@/lib/idle-task'
 import { cn } from '@/lib/utils'
 
 interface ItemImageProps {
@@ -103,37 +104,16 @@ export function ItemImage({
       return
     }
 
-    let cancelled = false
-    let idleCallbackId: number | null = null
-    let timeoutId: number | null = null
-
-    const decodeBlurhash = () => {
-      const decoded = decodeBlurhashToDataUrl(blurhash)
-      if (!cancelled) {
+    return scheduleIdleTask(
+      () => {
+        const decoded = decodeBlurhashToDataUrl(blurhash)
         setDecodedBlurhashState({ blurhash, dataUrl: decoded })
-      }
-    }
-
-    if (typeof window.requestIdleCallback === 'function') {
-      idleCallbackId = window.requestIdleCallback(decodeBlurhash, {
+      },
+      {
         timeout: 180,
-      })
-    } else {
-      timeoutId = window.setTimeout(decodeBlurhash, 100)
-    }
-
-    return () => {
-      cancelled = true
-      if (
-        idleCallbackId !== null &&
-        typeof window.cancelIdleCallback === 'function'
-      ) {
-        window.cancelIdleCallback(idleCallbackId)
-      }
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId)
-      }
-    }
+        fallbackDelay: 100,
+      },
+    )
   }, [blurhash, cachedBlurhashDataUrl])
 
   const imageKey = imageUrl || rawImageUrl || item.Id

--- a/src/components/media/ItemImage.tsx
+++ b/src/components/media/ItemImage.tsx
@@ -104,21 +104,35 @@ export function ItemImage({
     }
 
     let cancelled = false
-    const idleCallbackId = window.requestIdleCallback(
-      () => {
-        const decoded = decodeBlurhashToDataUrl(blurhash)
-        if (!cancelled) {
-          setDecodedBlurhashState({ blurhash, dataUrl: decoded })
-        }
-      },
-      {
+    let idleCallbackId: number | null = null
+    let timeoutId: number | null = null
+
+    const decodeBlurhash = () => {
+      const decoded = decodeBlurhashToDataUrl(blurhash)
+      if (!cancelled) {
+        setDecodedBlurhashState({ blurhash, dataUrl: decoded })
+      }
+    }
+
+    if (typeof window.requestIdleCallback === 'function') {
+      idleCallbackId = window.requestIdleCallback(decodeBlurhash, {
         timeout: 180,
-      },
-    )
+      })
+    } else {
+      timeoutId = window.setTimeout(decodeBlurhash, 100)
+    }
 
     return () => {
       cancelled = true
-      window.cancelIdleCallback(idleCallbackId)
+      if (
+        idleCallbackId !== null &&
+        typeof window.cancelIdleCallback === 'function'
+      ) {
+        window.cancelIdleCallback(idleCallbackId)
+      }
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId)
+      }
     }
   }, [blurhash, cachedBlurhashDataUrl])
 

--- a/src/lib/idle-task.ts
+++ b/src/lib/idle-task.ts
@@ -1,0 +1,51 @@
+interface IdleTaskOptions {
+  /** Maximum time to wait for an idle period when the API is available. */
+  timeout: number
+  /** Delay used by browsers that do not implement requestIdleCallback. */
+  fallbackDelay: number
+}
+
+/**
+ * Schedules non-urgent work and returns an idempotent cancellation function.
+ * Falls back to a timer when requestIdleCallback is unavailable.
+ */
+export function scheduleIdleTask(
+  task: () => void,
+  { timeout, fallbackDelay }: IdleTaskOptions,
+): () => void {
+  let idleCallbackId: number | null = null
+  let timeoutId: number | null = null
+  let cancelled = false
+
+  const runTask = () => {
+    idleCallbackId = null
+    timeoutId = null
+
+    if (!cancelled) {
+      task()
+    }
+  }
+
+  if (typeof window.requestIdleCallback === 'function') {
+    idleCallbackId = window.requestIdleCallback(runTask, { timeout })
+  } else {
+    timeoutId = window.setTimeout(runTask, fallbackDelay)
+  }
+
+  return () => {
+    cancelled = true
+
+    if (
+      idleCallbackId !== null &&
+      typeof window.cancelIdleCallback === 'function'
+    ) {
+      window.cancelIdleCallback(idleCallbackId)
+    }
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId)
+    }
+
+    idleCallbackId = null
+    timeoutId = null
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared helper for scheduling non-urgent work with requestIdleCallback and safe fallbacks, and adopt it in filter and media components.

Bug Fixes:
- Prevent runtime errors when cancelIdleCallback is missing or requestIdleCallback is unavailable by guarding and falling back to setTimeout.

Enhancements:
- Extract idle task scheduling into a reusable scheduleIdleTask utility and use it in FilterView and ItemImage to centralize cancellation and fallback behavior.

Tests:
- Add unit tests for the scheduleIdleTask helper to verify fallback behavior and cancellation semantics.