### PR TITLE
Add monochrome appearance setting

### DIFF
--- a/src/__tests__/properties/settings-persistence.property.test.ts
+++ b/src/__tests__/properties/settings-persistence.property.test.ts
@@ -20,6 +20,7 @@ type Locale = 'en-US' | 'de' | 'fr' | 'auto'
 
 interface AppSettings {
   theme: Theme
+  monochrome: boolean
   locale: Locale
   showVideoPlayer: boolean
   enableEdl: boolean
@@ -48,6 +49,7 @@ const apiKeyArb = fc.option(
 
 const appSettingsArb = fc.record<AppSettings>({
   theme: themeArb,
+  monochrome: booleanArb,
   locale: localeArb,
   showVideoPlayer: booleanArb,
   enableEdl: booleanArb,
@@ -98,6 +100,7 @@ describe('Settings Persistence Round-Trip', () => {
         const restored = parsed.state as AppSettings
 
         expect(restored.theme).toBe(settings.theme)
+        expect(restored.monochrome).toBe(settings.monochrome)
         expect(restored.locale).toBe(settings.locale)
         expect(restored.showVideoPlayer).toBe(settings.showVideoPlayer)
         expect(restored.enableEdl).toBe(settings.enableEdl)
@@ -144,6 +147,7 @@ describe('Settings Persistence Round-Trip', () => {
         const initialState = {
           state: {
             theme: 'auto' as Theme,
+            monochrome: false,
             locale: 'en-US' as Locale,
             showVideoPlayer: true,
             enableEdl: false,
@@ -176,6 +180,7 @@ describe('Settings Persistence Round-Trip', () => {
         const initialState = {
           state: {
             theme: 'auto' as Theme,
+            monochrome: false,
             locale: 'en-US' as Locale,
             showVideoPlayer: true,
             enableEdl: false,
@@ -224,6 +229,7 @@ describe('Settings Persistence Round-Trip', () => {
           const restored = parsed.state as AppSettings
 
           expect(restored.theme).toBe(finalSettings.theme)
+          expect(restored.monochrome).toBe(finalSettings.monochrome)
           expect(restored.locale).toBe(finalSettings.locale)
           expect(restored.showVideoPlayer).toBe(finalSettings.showVideoPlayer)
           expect(restored.enableEdl).toBe(finalSettings.enableEdl)
@@ -256,6 +262,47 @@ describe('Settings Persistence Round-Trip', () => {
     await useAppStore.persist.rehydrate()
 
     expect(useAppStore.getState().jellyfinPlaybackSyncEnabled).toBe(false)
+  })
+
+  it('defaults monochrome to disabled during app settings migration', async () => {
+    const previousState = {
+      theme: 'auto' as Theme,
+      locale: 'en-US' as Locale,
+      showVideoPlayer: true,
+      enableEdl: false,
+      enableChapter: false,
+      jellyfinPlaybackSyncEnabled: false,
+    }
+
+    localStorage.setItem(
+      APP_STORAGE_KEY,
+      JSON.stringify({ state: previousState, version: 2 }),
+    )
+
+    await useAppStore.persist.rehydrate()
+
+    expect(useAppStore.getState().monochrome).toBe(false)
+  })
+
+  it('preserves enabled monochrome during app settings migration', async () => {
+    const previousState = {
+      theme: 'auto' as Theme,
+      monochrome: true,
+      locale: 'en-US' as Locale,
+      showVideoPlayer: true,
+      enableEdl: false,
+      enableChapter: false,
+      jellyfinPlaybackSyncEnabled: false,
+    }
+
+    localStorage.setItem(
+      APP_STORAGE_KEY,
+      JSON.stringify({ state: previousState, version: 2 }),
+    )
+
+    await useAppStore.persist.rehydrate()
+
+    expect(useAppStore.getState().monochrome).toBe(true)
   })
 
   it('preserves enabled playback sync during app settings migration', async () => {
@@ -292,6 +339,22 @@ describe('Settings Persistence Round-Trip', () => {
     stored = localStorage.getItem(APP_STORAGE_KEY)
     expect(stored).not.toBeNull()
     expect(JSON.parse(stored!).state.jellyfinPlaybackSyncEnabled).toBe(false)
+  })
+
+  it('persists monochrome setter updates immediately', () => {
+    localStorage.removeItem(APP_STORAGE_KEY)
+
+    useAppStore.getState().setMonochrome(true)
+
+    let stored = localStorage.getItem(APP_STORAGE_KEY)
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored!).state.monochrome).toBe(true)
+
+    useAppStore.getState().setMonochrome(false)
+
+    stored = localStorage.getItem(APP_STORAGE_KEY)
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored!).state.monochrome).toBe(false)
   })
 
   it('persists server address and API key together', () => {

--- a/src/__tests__/properties/settings-persistence.property.test.ts
+++ b/src/__tests__/properties/settings-persistence.property.test.ts
@@ -343,18 +343,25 @@ describe('Settings Persistence Round-Trip', () => {
 
   it('persists monochrome setter updates immediately', () => {
     localStorage.removeItem(APP_STORAGE_KEY)
+    document.documentElement.classList.remove('monochrome')
 
-    useAppStore.getState().setMonochrome(true)
+    const { setMonochrome } = useAppStore.getState()
 
-    let stored = localStorage.getItem(APP_STORAGE_KEY)
-    expect(stored).not.toBeNull()
-    expect(JSON.parse(stored!).state.monochrome).toBe(true)
+    setMonochrome(true)
 
-    useAppStore.getState().setMonochrome(false)
+    const storedAfterEnable = localStorage.getItem(APP_STORAGE_KEY)
+    expect(storedAfterEnable).not.toBeNull()
+    expect(JSON.parse(storedAfterEnable!).state.monochrome).toBe(true)
+    expect(document.documentElement.classList.contains('monochrome')).toBe(true)
 
-    stored = localStorage.getItem(APP_STORAGE_KEY)
-    expect(stored).not.toBeNull()
-    expect(JSON.parse(stored!).state.monochrome).toBe(false)
+    setMonochrome(false)
+
+    const storedAfterDisable = localStorage.getItem(APP_STORAGE_KEY)
+    expect(storedAfterDisable).not.toBeNull()
+    expect(JSON.parse(storedAfterDisable!).state.monochrome).toBe(false)
+    expect(document.documentElement.classList.contains('monochrome')).toBe(
+      false,
+    )
   })
 
   it('persists server address and API key together', () => {

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -1,29 +1,77 @@
 import { useTranslation } from 'react-i18next'
 import { Palette } from 'lucide-react'
 
-import { SelectSettingsSection } from '../primitives/SelectSettingsSection'
+import { SettingsSection } from '../primitives/SettingsSection'
+import { SettingsSelect } from '../primitives/SettingsSelect'
 import type { SelectOption } from '../primitives/SettingsSelect'
 import type { Theme } from '@/stores/app-store'
 import { useAppStore } from '@/stores/app-store'
+import { cn } from '@/lib/utils'
 
 export function AppearanceSection() {
   const { t } = useTranslation()
   const theme = useAppStore((s) => s.theme)
   const setTheme = useAppStore((s) => s.setTheme)
+  const monochrome = useAppStore((s) => s.monochrome)
+  const setMonochrome = useAppStore((s) => s.setMonochrome)
 
   const options: Array<SelectOption<Theme>> = [
     { value: 'auto', label: t('app.theme.system') },
     { value: 'dark', label: t('app.theme.dark') },
     { value: 'light', label: t('app.theme.light') },
   ]
+  const title = t('app.theme.title')
+  const monochromeLabel = t('app.theme.monochrome')
+  const monochromeDescription = t('app.theme.monochromeDescription')
 
   return (
-    <SelectSettingsSection
-      icon={Palette}
-      titleKey="app.theme.title"
-      value={theme}
-      onValueChange={setTheme}
-      options={options}
-    />
+    <SettingsSection icon={Palette} title={title}>
+      <div className="space-y-3">
+        <SettingsSelect
+          value={theme}
+          onValueChange={setTheme}
+          options={options}
+          aria-label={title}
+        />
+        <button
+          type="button"
+          aria-pressed={monochrome}
+          onClick={() => setMonochrome(!monochrome)}
+          className={cn(
+            'flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-sm transition-[background-color,border-color,color,box-shadow]',
+            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none',
+            monochrome
+              ? 'border-primary/40 bg-primary/10 text-foreground'
+              : 'border-border/70 bg-input/20 hover:bg-muted/50',
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Palette className="size-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0">
+              <span className="block font-medium">{monochromeLabel}</span>
+              <span className="block text-xs text-muted-foreground">
+                {monochromeDescription}
+              </span>
+            </span>
+          </span>
+          <span
+            aria-hidden="true"
+            className={cn(
+              'relative h-5 w-9 shrink-0 rounded-full border transition-colors',
+              monochrome
+                ? 'border-primary bg-primary'
+                : 'border-border bg-muted',
+            )}
+          >
+            <span
+              className={cn(
+                'absolute top-1/2 size-4 -translate-y-1/2 rounded-full bg-background shadow-sm transition-transform',
+                monochrome ? 'translate-x-4' : 'translate-x-0.5',
+              )}
+            />
+          </span>
+        </button>
+      </div>
+    </SettingsSection>
   )
 }

--- a/src/hooks/use-vibrant-color.ts
+++ b/src/hooks/use-vibrant-color.ts
@@ -6,7 +6,7 @@ import type { Theme } from '@/stores/app-store'
 import type { VibrantColors } from '@/lib/cache-manager'
 import { LRUCache, blobCache, fetchBlobUrl } from '@/lib/cache-manager'
 import { CACHE_CONFIG } from '@/lib/constants'
-import { selectTheme, useAppStore } from '@/stores/app-store'
+import { selectMonochrome, selectTheme, useAppStore } from '@/stores/app-store'
 
 export type { VibrantColors } from '@/lib/cache-manager'
 
@@ -384,6 +384,8 @@ export const preloadVibrantColors = (
   urls: ReadonlyArray<string>,
   theme: Theme = 'auto',
 ): void => {
+  if (useAppStore.getState().monochrome) return
+
   const resolved = resolveTheme(theme)
   const cache = getCache(resolved)
   for (const url of urls) {
@@ -399,7 +401,8 @@ export function useVibrantColor(
   imageUrl: string | null,
   options?: UseVibrantColorOptions,
 ): VibrantColors | null {
-  const enabled = options?.enabled ?? true
+  const monochrome = useAppStore(selectMonochrome)
+  const enabled = (options?.enabled ?? true) && !monochrome
   const theme = useAppStore(selectTheme)
   const resolvedTheme = resolveTheme(theme)
   const cachedColors = useSyncExternalStore(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -87,7 +87,9 @@
       "title": "Stil",
       "system": "System",
       "dark": "Dunkel",
-      "light": "Hell"
+      "light": "Hell",
+      "monochrome": "Monochrom",
+      "monochromeDescription": "Artwork- und Akzentfarben deaktivieren"
     },
     "locale": {
       "auto": "Auto",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -87,7 +87,9 @@
       "title": "Theme",
       "system": "System",
       "dark": "Dark",
-      "light": "Light"
+      "light": "Light",
+      "monochrome": "Monochrome",
+      "monochromeDescription": "Disable artwork and accent colors"
     },
     "locale": {
       "auto": "Auto",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -44,7 +44,9 @@
       "title": "Thème",
       "system": "Système",
       "dark": "Sombre",
-      "light": "Clair"
+      "light": "Clair",
+      "monochrome": "Monochrome",
+      "monochromeDescription": "Désactiver les couleurs d'illustration et d'accentuation"
     },
     "locale": {
       "auto": "Auto",

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -22,6 +22,7 @@ interface TrackPreferences {
 
 interface AppState {
   theme: Theme
+  monochrome: boolean
   locale: Locale
   showVideoPlayer: boolean
   enableEdl: boolean
@@ -36,6 +37,7 @@ interface AppState {
 
 interface AppActions {
   setTheme: (theme: Theme) => void
+  setMonochrome: (monochrome: boolean) => void
   setLocale: (locale: Locale) => void
   setShowVideoPlayer: (show: boolean) => void
   setEnableEdl: (enable: boolean) => void
@@ -69,6 +71,15 @@ const applyTheme = (theme: Theme): void => {
   }
 }
 
+const applyMonochrome = (monochrome: boolean): void => {
+  if (typeof document === 'undefined') return
+  try {
+    document.documentElement.classList.toggle('monochrome', monochrome)
+  } catch {
+    /* ignore in test/SSR */
+  }
+}
+
 const detectBrowserLocale = (): ResolvedLocale => {
   if (typeof navigator === 'undefined') return 'en-US'
   const lang = navigator.language
@@ -79,6 +90,7 @@ const detectBrowserLocale = (): ResolvedLocale => {
 
 const initialState: AppState = {
   theme: 'auto',
+  monochrome: false,
   locale: 'auto',
   showVideoPlayer: true,
   enableEdl: false,
@@ -100,6 +112,10 @@ export const useAppStore = create<AppStore>()(
       setTheme: (theme) => {
         applyTheme(theme)
         set({ theme })
+      },
+      setMonochrome: (monochrome) => {
+        applyMonochrome(monochrome)
+        set({ monochrome })
       },
       setLocale: (locale) => set({ locale }),
       setShowVideoPlayer: (showVideoPlayer) => set({ showVideoPlayer }),
@@ -140,7 +156,7 @@ export const useAppStore = create<AppStore>()(
     }),
     {
       name: 'segment-editor-app',
-      version: 2,
+      version: 3,
       migrate: (persistedState: unknown, version: number) => {
         if (typeof persistedState !== 'object' || persistedState === null) {
           return persistedState
@@ -152,10 +168,16 @@ export const useAppStore = create<AppStore>()(
         if (version < 2 && !('jellyfinPlaybackSyncEnabled' in state)) {
           state = { ...state, jellyfinPlaybackSyncEnabled: false }
         }
+        if (version < 3 && !('monochrome' in state)) {
+          state = { ...state, monochrome: false }
+        }
         return state
       },
       onRehydrateStorage: () => (state) => {
-        if (state) applyTheme(state.theme)
+        if (state) {
+          applyTheme(state.theme)
+          applyMonochrome(state.monochrome)
+        }
       },
     },
   ),
@@ -165,3 +187,4 @@ export const getEffectiveLocale = (locale: Locale): ResolvedLocale =>
   locale === 'auto' ? detectBrowserLocale() : locale
 
 export const selectTheme = (state: AppStore): Theme => state.theme
+export const selectMonochrome = (state: AppStore): boolean => state.monochrome

--- a/src/styles.css
+++ b/src/styles.css
@@ -138,6 +138,48 @@
   --sidebar-ring: oklch(0.7214 0.1337 49.9802);
 }
 
+.monochrome {
+  --primary: oklch(0.48 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.62 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.48 0 0);
+  --chart-1: oklch(0.36 0 0);
+  --chart-2: oklch(0.48 0 0);
+  --chart-3: oklch(0.6 0 0);
+  --chart-4: oklch(0.72 0 0);
+  --chart-5: oklch(0.84 0 0);
+  --segment-intro: oklch(0.42 0 0);
+  --segment-outro: oklch(0.5 0 0);
+  --segment-preview: oklch(0.58 0 0);
+  --segment-recap: oklch(0.66 0 0);
+  --segment-commercial: oklch(0.34 0 0);
+  --segment-unknown: oklch(0.54 0 0);
+  --sidebar-primary: oklch(0.48 0 0);
+  --sidebar-ring: oklch(0.48 0 0);
+}
+
+.dark.monochrome {
+  --primary: oklch(0.76 0 0);
+  --primary-foreground: oklch(0.18 0 0);
+  --secondary: oklch(0.58 0 0);
+  --secondary-foreground: oklch(0.18 0 0);
+  --ring: oklch(0.76 0 0);
+  --chart-1: oklch(0.3 0 0);
+  --chart-2: oklch(0.42 0 0);
+  --chart-3: oklch(0.54 0 0);
+  --chart-4: oklch(0.66 0 0);
+  --chart-5: oklch(0.78 0 0);
+  --segment-intro: oklch(0.42 0 0);
+  --segment-outro: oklch(0.5 0 0);
+  --segment-preview: oklch(0.58 0 0);
+  --segment-recap: oklch(0.66 0 0);
+  --segment-commercial: oklch(0.74 0 0);
+  --segment-unknown: oklch(0.6 0 0);
+  --sidebar-primary: oklch(0.76 0 0);
+  --sidebar-ring: oklch(0.76 0 0);
+}
+
 @theme inline {
   --font-sans: 'DM Sans Variable', ui-sans-serif, system-ui, sans-serif;
   --font-serif: serif;


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable monochrome appearance mode and integrate it with theming, persistence, and color handling.

New Features:
- Introduce a monochrome appearance toggle in the appearance settings that controls a global monochrome theme variant.

Enhancements:
- Extend the app store to track and expose a monochrome flag, applying a corresponding CSS class to the document and updating CSS theme tokens for monochrome and dark-monochrome modes.
- Update vibrant color handling to disable dynamic color extraction when monochrome mode is enabled.

Tests:
- Expand settings persistence property tests to cover the monochrome flag, including migration from older versions and immediate persistence of monochrome changes.