### PR TITLE
fix(player): stop clipping video under rounded corners to fix JASSUB black frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ package-lock.json
 
 # Generated mock-server poster cache
 tools/images/
+
+# Local mock-server video fixture
+tools/video.mp4

--- a/src/__tests__/player-surface.test.tsx
+++ b/src/__tests__/player-surface.test.tsx
@@ -259,12 +259,16 @@ describe('PlayerSurface', () => {
     expect(backdropClip.getAttribute('aria-hidden')).toBe('true')
     expect(backdropClip.classList.contains('overflow-hidden')).toBe(true)
     expect(backdropClip.classList.contains('rounded-2xl')).toBe(true)
+    // The clipping wrapper must only ever contain the backdrop, never the
+    // video (see the JASSUB black-frame guard below).
+    expect(backdropClip.contains(video)).toBe(false)
   })
 
-  it('never clips the video behind an overflow-hidden ancestor (JASSUB black-frame guard)', () => {
+  it('never clips the video behind an overflow-clipping ancestor (JASSUB black-frame guard)', () => {
     // Chromium renders hardware-decoded video black when an ancestor
-    // border-radius + overflow clip has to mask the composited JASSUB
-    // subtitle canvas layered above the video.
+    // border-radius + overflow clip (hidden or clip, any axis) has to mask
+    // the composited JASSUB subtitle canvas layered above the video.
+    const overflowClipClass = /\boverflow-(?:x-|y-)?(?:hidden|clip)\b/
     const { container } = render(
       <PlayerSurface
         {...createProps({
@@ -277,7 +281,7 @@ describe('PlayerSurface', () => {
     if (!video) throw new Error('Expected video element')
 
     for (let node = video.parentElement; node; node = node.parentElement) {
-      expect(node.classList.contains('overflow-hidden')).toBe(false)
+      expect(node.getAttribute('class') ?? '').not.toMatch(overflowClipClass)
     }
   })
 

--- a/src/__tests__/player-surface.test.tsx
+++ b/src/__tests__/player-surface.test.tsx
@@ -276,11 +276,7 @@ describe('PlayerSurface', () => {
     const video = container.querySelector('video')
     if (!video) throw new Error('Expected video element')
 
-    for (
-      let node = video.parentElement;
-      node;
-      node = node.parentElement
-    ) {
+    for (let node = video.parentElement; node; node = node.parentElement) {
       expect(node.classList.contains('overflow-hidden')).toBe(false)
     }
   })

--- a/src/__tests__/player-surface.test.tsx
+++ b/src/__tests__/player-surface.test.tsx
@@ -243,14 +243,46 @@ describe('PlayerSurface', () => {
       name: 'player.videoPlayer',
     })
     expect(videoButton.classList.contains('rounded-2xl')).toBe(true)
-    expect(videoButton.classList.contains('overflow-hidden')).toBe(true)
     expect(videoButton.classList.contains('aspect-video')).toBe(true)
+
+    const video = container.querySelector('video')
+    if (!video) throw new Error('Expected video element')
+    expect(video.classList.contains('rounded-2xl')).toBe(true)
 
     const backdrop = container.querySelector('img')
     if (!backdrop) throw new Error('Expected blurred poster backdrop')
     expect(backdrop.getAttribute('src')).toBe('/poster.jpg')
-    expect(backdrop.getAttribute('aria-hidden')).toBe('true')
     expect(backdrop.classList.contains('blur-2xl')).toBe(true)
+
+    const backdropClip = backdrop.parentElement
+    if (!backdropClip) throw new Error('Expected backdrop clipping wrapper')
+    expect(backdropClip.getAttribute('aria-hidden')).toBe('true')
+    expect(backdropClip.classList.contains('overflow-hidden')).toBe(true)
+    expect(backdropClip.classList.contains('rounded-2xl')).toBe(true)
+  })
+
+  it('never clips the video behind an overflow-hidden ancestor (JASSUB black-frame guard)', () => {
+    // Chromium renders hardware-decoded video black when an ancestor
+    // border-radius + overflow clip has to mask the composited JASSUB
+    // subtitle canvas layered above the video.
+    const { container } = render(
+      <PlayerSurface
+        {...createProps({
+          video: { posterUrl: '/poster.jpg' },
+        })}
+      />,
+    )
+
+    const video = container.querySelector('video')
+    if (!video) throw new Error('Expected video element')
+
+    for (
+      let node = video.parentElement;
+      node;
+      node = node.parentElement
+    ) {
+      expect(node.classList.contains('overflow-hidden')).toBe(false)
+    }
   })
 
   it('drops the rounded frame and poster backdrop in fullscreen', () => {

--- a/src/components/player/PlayerSurface.tsx
+++ b/src/components/player/PlayerSurface.tsx
@@ -95,21 +95,31 @@ function PlayerVideoButton({
         'relative block w-full border-0 bg-transparent p-0 text-left text-inherit',
         isFullscreen
           ? cn('w-full h-full', showControls ? 'cursor-default' : 'cursor-none')
-          : 'aspect-video cursor-pointer overflow-hidden rounded-2xl bg-black',
+          : 'aspect-video cursor-pointer rounded-2xl bg-black',
       )}
       onClick={video.onInteraction}
       onTouchEnd={video.onInteraction}
       onKeyDown={video.onKeyDown}
       aria-label={t('player.videoPlayer')}
     >
+      {/* The rounded frame must NOT clip the video via an ancestor (overflow-hidden):
+          combining an ancestor border-radius clip with the composited JASSUB
+          subtitle canvas forces Chromium to mask the hardware video layer, which
+          renders the video black on some GPUs once the first subtitle paints.
+          Instead the button background and the video element are rounded
+          individually, and only the blurred backdrop gets its own clipping box. */}
       {/* Blurred cover backdrop keeps portrait posters looking intentional inside the 16:9 box */}
       {!isFullscreen && video.posterUrl ? (
-        <img
-          src={video.posterUrl}
-          alt=""
+        <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 h-full w-full object-cover blur-2xl scale-110 opacity-40"
-        />
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-2xl"
+        >
+          <img
+            src={video.posterUrl}
+            alt=""
+            className="h-full w-full object-cover blur-2xl scale-110 opacity-40"
+          />
+        </div>
       ) : null}
       {/* Captions are data-dependent: native VTT tracks are rendered when Jellyfin exposes them; ASS/SSA subtitles are rendered by JASSUB. */}
       {/* react-doctor-disable-next-line react-doctor/media-has-caption */}
@@ -121,7 +131,7 @@ function PlayerVideoButton({
                 'w-full h-full',
                 videoFitMode === 'contain' ? 'object-contain' : 'object-cover',
               )
-            : 'absolute inset-0 h-full w-full object-contain',
+            : 'absolute inset-0 h-full w-full rounded-2xl object-contain',
         )}
         poster={video.posterUrl ?? undefined}
         crossOrigin="anonymous"

--- a/tools/server.mjs
+++ b/tools/server.mjs
@@ -690,7 +690,10 @@ const server = http.createServer(async (req, res) => {
   }
 
   // ASS subtitle stream (JASSUB)
-  m = /^\/Videos\/[0-9a-f-]+\/[0-9a-f-]+\/Subtitles\/\d+\/Stream\.(ass|ssa)$/i.exec(p)
+  m =
+    /^\/Videos\/[0-9a-f-]+\/[0-9a-f-]+\/Subtitles\/\d+\/Stream\.(ass|ssa)$/i.exec(
+      p,
+    )
   if (m) {
     const assPath = path.join(__dirname, 'sub.ass')
     if (!fs.existsSync(assPath)) return notFound(res)

--- a/tools/server.mjs
+++ b/tools/server.mjs
@@ -167,6 +167,15 @@ function makeMediaSource(id) {
         IsDefault: true,
         DisplayTitle: 'English - AAC - Stereo',
       },
+      {
+        Type: 'Subtitle',
+        Codec: 'ass',
+        Index: 2,
+        Language: 'eng',
+        IsDefault: false,
+        IsExternal: false,
+        DisplayTitle: 'English - ASS',
+      },
     ],
   }
 }
@@ -678,6 +687,15 @@ const server = http.createServer(async (req, res) => {
     }
     res.writeHead(204)
     return res.end()
+  }
+
+  // ASS subtitle stream (JASSUB)
+  m = /^\/Videos\/[0-9a-f-]+\/[0-9a-f-]+\/Subtitles\/\d+\/Stream\.(ass|ssa)$/i.exec(p)
+  if (m) {
+    const assPath = path.join(__dirname, 'sub.ass')
+    if (!fs.existsSync(assPath)) return notFound(res)
+    res.writeHead(200, { 'Content-Type': 'text/x-ssa; charset=utf-8' })
+    return res.end(fs.readFileSync(assPath))
   }
 
   // Video stream (direct play)

--- a/tools/sub.ass
+++ b/tools/sub.ass
@@ -1,0 +1,15 @@
+[Script Info]
+Title: Repro
+ScriptType: v4.00+
+PlayResX: 1280
+PlayResY: 720
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Liberation Sans,48,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,0,0,0,0,100,100,0,0,1,3,1,2,30,30,40,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:06.00,Default,,0,0,0,,First subtitle line appears here
+Dialogue: 0,0:00:07.00,0:00:12.00,Default,,0,0,0,,Second subtitle line
+Dialogue: 0,0:00:13.00,0:00:25.00,Default,,0,0,0,,Third subtitle - long duration


### PR DESCRIPTION
## Problem

Since #196 the windowed player wraps the `<video>` (and the JASSUB subtitle canvas, which jassub 2.5.7 inserts as the video's next sibling) in a button with `overflow-hidden rounded-2xl`.

That combination is a known-fragile Chromium compositing configuration: when the composited JASSUB `OffscreenCanvas` paints its first subtitle above the video, the ancestor border-radius + overflow clip has to be applied as a mask over the hardware video layer, and on hardware-decode paths this renders the video image as a black frame (see the crbug family around border-radius clipping of composited video children, e.g. issues.chromium.org/343519251). Symptom reported: video goes black exactly when the first ASS subtitle line renders.

## Fix

Keep the rounded look, but never clip the video/canvas subtree through an ancestor:

- Button keeps `rounded-2xl bg-black` (background respects radius without `overflow-hidden`) and drops `overflow-hidden`
- The `<video>` element is rounded directly (`rounded-2xl`), which Chromium handles on the media layer itself
- The blurred poster backdrop (`blur-2xl scale-110`, which previously relied on the ancestor clip to stay contained) moves into its own `overflow-hidden rounded-2xl` wrapper that contains no video/canvas
- Fullscreen path unchanged (no rounding there)

## Tests / verification

- New regression test asserting the `<video>` has no `overflow-hidden` ancestor (JASSUB black-frame guard), updated windowed-surface test for the new structure; full suite passes (570/570)
- Verified live against the dev mock server: ASS subtitles render via JASSUB over a playing video with rounded corners intact and the backdrop still contained
- `tools/server.mjs` now exposes an ASS subtitle stream (`English - ASS`) backed by `tools/sub.ass` so JASSUB flows can be reproduced against the mock server (video fixture `tools/video.mp4` stays local/gitignored)

Note: the black frame itself only reproduces on hardware-decode GPU paths, so it can't be demonstrated on a software-rendered VM; the fix removes the triggering configuration.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/c839177d-6c89-4eea-a6d6-e02f13dde26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/c839177d-6c89-4eea-a6d6-e02f13dde26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-092"><img alt="INTRO-092" src="https://capy.ai/api/badge/thread.svg?label=INTRO-092"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Adjust player surface layout to preserve rounded corners without clipping the video, preventing JASSUB-related black frames on some GPUs.

New Features:
- Expose an ASS subtitle stream in the mock server to support JASSUB subtitle flows during development.

Bug Fixes:
- Ensure the windowed player no longer places the video under an overflow-hidden ancestor, avoiding black frames when JASSUB subtitles render.

Enhancements:
- Round the video element and backdrop container independently so the player retains its rounded visual style while remaining compatible with hardware-decoded video compositing.

Tests:
- Add a regression test verifying the video has no overflow-hidden ancestors and update the windowed player surface test for the new DOM structure.

Chores:
- Add an ASS subtitle fixture file to the tools directory and configure the dev server to serve it.