### PR TITLE
Add visual segment timeline to the episode list

### DIFF
--- a/src/__tests__/segment-region-utils.test.ts
+++ b/src/__tests__/segment-region-utils.test.ts
@@ -86,6 +86,39 @@ describe('getSegmentRegions', () => {
     ).toEqual([])
   })
 
+  it('treats missing ticks as 0 and clamps to the runtime', () => {
+    const noStart: MediaSegmentDto = {
+      Id: 'seg-no-start',
+      ItemId: 'item-1',
+      Type: MediaSegmentType.Intro,
+      EndTicks: 400,
+    }
+    const regions = getSegmentRegions([noStart], 300)
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].start).toBe(0)
+    expect(regions[0].width).toBe(100)
+    expect(regions[0].startSeconds).toBe(0)
+    expect(regions[0].endSeconds).toBe(300)
+  })
+
+  it('drops reversed spans (end before start) in both modes', () => {
+    const reversed = segment(90, 30)
+    const noEnd: MediaSegmentDto = {
+      Id: 'seg-no-end',
+      ItemId: 'item-1',
+      Type: MediaSegmentType.Intro,
+      StartTicks: 120,
+    }
+
+    expect(getSegmentRegions([reversed, noEnd], 300)).toEqual([])
+    expect(
+      getSegmentRegions([reversed, noEnd], 300, {
+        minVisibleWidthPercent: 0.8,
+      }),
+    ).toEqual([])
+  })
+
   it('falls back to the unknown color for untyped segments', () => {
     const untyped: MediaSegmentDto = {
       Id: 'seg-untyped',

--- a/src/__tests__/segment-region-utils.test.ts
+++ b/src/__tests__/segment-region-utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MediaSegmentDto } from '@/types/jellyfin'
+import { MediaSegmentType } from '@/types/jellyfin'
+import { getSegmentRegions } from '@/lib/segment-utils'
+
+// StartTicks/EndTicks are in SECONDS at the UI boundary (see segments/api.ts)
+const segment = (
+  start: number,
+  end: number,
+  type: MediaSegmentType = MediaSegmentType.Intro,
+  id = `seg-${start}-${end}`,
+): MediaSegmentDto => ({
+  Id: id,
+  ItemId: 'item-1',
+  Type: type,
+  StartTicks: start,
+  EndTicks: end,
+})
+
+describe('getSegmentRegions', () => {
+  it('returns empty for missing segments or non-positive duration', () => {
+    expect(getSegmentRegions(undefined, 100)).toEqual([])
+    expect(getSegmentRegions([], 100)).toEqual([])
+    expect(getSegmentRegions([segment(0, 10)], 0)).toEqual([])
+    expect(getSegmentRegions([segment(0, 10)], -5)).toEqual([])
+  })
+
+  it('maps segments to percent-based regions with second bounds', () => {
+    const regions = getSegmentRegions([segment(30, 90)], 300)
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].start).toBeCloseTo(10)
+    expect(regions[0].width).toBeCloseTo(20)
+    expect(regions[0].startSeconds).toBe(30)
+    expect(regions[0].endSeconds).toBe(90)
+    expect(regions[0].color).toBe('var(--segment-intro)')
+  })
+
+  it('clamps regions that extend beyond the runtime', () => {
+    const regions = getSegmentRegions([segment(-10, 400)], 300)
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].start).toBe(0)
+    expect(regions[0].width).toBe(100)
+    expect(regions[0].startSeconds).toBe(0)
+    expect(regions[0].endSeconds).toBe(300)
+  })
+
+  it('drops segments starting at or beyond the runtime', () => {
+    expect(getSegmentRegions([segment(300, 360)], 300)).toEqual([])
+    expect(getSegmentRegions([segment(500, 600)], 300)).toEqual([])
+  })
+
+  it('drops sub-0.1% regions by default (scrubber behavior)', () => {
+    // 1s of a 24min episode is ~0.069% wide
+    expect(getSegmentRegions([segment(10, 11)], 1440)).toEqual([])
+  })
+
+  it('widens tiny regions instead of dropping them when a minimum is set', () => {
+    const regions = getSegmentRegions([segment(10, 11)], 1440, {
+      minVisibleWidthPercent: 0.8,
+    })
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].width).toBe(0.8)
+    expect(regions[0].start).toBeCloseTo((10 / 1440) * 100)
+  })
+
+  it('shifts widened regions left at the track end so they stay in bounds', () => {
+    const regions = getSegmentRegions([segment(1439, 1440)], 1440, {
+      minVisibleWidthPercent: 0.8,
+    })
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].width).toBe(0.8)
+    expect(regions[0].start).toBeCloseTo(99.2)
+    expect(regions[0].start + regions[0].width).toBeLessThanOrEqual(100)
+  })
+
+  it('still drops zero-width spans when a minimum is set', () => {
+    expect(
+      getSegmentRegions([segment(10, 10)], 1440, {
+        minVisibleWidthPercent: 0.8,
+      }),
+    ).toEqual([])
+  })
+
+  it('falls back to the unknown color for untyped segments', () => {
+    const untyped: MediaSegmentDto = {
+      Id: 'seg-untyped',
+      ItemId: 'item-1',
+      StartTicks: 0,
+      EndTicks: 50,
+    }
+    const regions = getSegmentRegions([untyped], 100)
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].color).toBe('var(--segment-unknown)')
+  })
+})

--- a/src/__tests__/segment-region-utils.test.ts
+++ b/src/__tests__/segment-region-utils.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import { MediaSegmentType } from '@/types/jellyfin'
-import { getSegmentRegions } from '@/lib/segment-utils'
+import {
+  getSegmentColor,
+  getSegmentCssVar,
+  getSegmentRegions,
+} from '@/lib/segment-utils'
 
 // StartTicks/EndTicks are in SECONDS at the UI boundary (see segments/api.ts)
 const segment = (
@@ -130,5 +134,30 @@ describe('getSegmentRegions', () => {
 
     expect(regions).toHaveLength(1)
     expect(regions[0].color).toBe('var(--segment-unknown)')
+  })
+
+  it('does not crash on server enum values unknown to this client', () => {
+    // A newer Jellyfin server may report types this client does not know;
+    // the schema warning is logged but DTOs are still forwarded to the UI.
+    const futureType: MediaSegmentDto = {
+      Id: 'seg-future',
+      ItemId: 'item-1',
+      Type: 'HolidaySpecial' as MediaSegmentType,
+      StartTicks: 10,
+      EndTicks: 60,
+    }
+    const regions = getSegmentRegions([futureType], 100)
+
+    expect(regions).toHaveLength(1)
+    expect(regions[0].color).toBe('var(--segment-unknown)')
+  })
+
+  it('resolves helper colors safely for unknown types', () => {
+    const futureType = 'HolidaySpecial' as MediaSegmentType
+
+    expect(getSegmentColor(futureType)).toBe('bg-segment-unknown')
+    expect(getSegmentCssVar(futureType)).toBe('var(--segment-unknown)')
+    expect(getSegmentColor(undefined)).toBe('bg-segment-unknown')
+    expect(getSegmentCssVar(undefined)).toBe('var(--segment-unknown)')
   })
 })

--- a/src/__tests__/segment-timeline.test.tsx
+++ b/src/__tests__/segment-timeline.test.tsx
@@ -14,6 +14,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     i18n: { changeLanguage: vi.fn(), language: 'en-US' },
     t: (_key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+      // Prove type-label localization is wired without translating every key
+      if (_key === 'segmentType.Recap') return 'Zusammenfassung'
       if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
       if (fallbackOrOptions && typeof fallbackOrOptions === 'object') {
         const { defaultValue, ...params } = fallbackOrOptions
@@ -98,6 +100,23 @@ describe('SegmentTimeline', () => {
     const regions = Array.from(timeline.children) as Array<HTMLElement>
     expect(regions).toHaveLength(1)
     expect(regions[0].style.width).toBe('0.8%')
+  })
+
+  it('localizes segment type names in tooltips and accessible labels', () => {
+    render(
+      <SegmentTimeline
+        segments={[segment(10, 60, MediaSegmentType.Recap)]}
+        runtimeSeconds={1440}
+      />,
+    )
+
+    const timeline = screen.getByTestId('segment-timeline')
+    expect(timeline.getAttribute('aria-label')).toBe(
+      'Segments: Zusammenfassung 0:10 – 1:00',
+    )
+
+    const regions = Array.from(timeline.children) as Array<HTMLElement>
+    expect(regions[0].title).toBe('Zusammenfassung 0:10 – 1:00')
   })
 
   it('renders an empty labelled track when no segments exist', () => {

--- a/src/__tests__/segment-timeline.test.tsx
+++ b/src/__tests__/segment-timeline.test.tsx
@@ -74,10 +74,9 @@ describe('SegmentTimeline', () => {
       />,
     )
 
-    const timeline = screen.getByTestId('segment-timeline')
-    expect(timeline.getAttribute('aria-label')).toBe(
-      'Segments: Intro 0:00 – 1:30, Outro 20:00 – 24:00',
-    )
+    const timeline = screen.getByRole('img', {
+      name: 'Segments: Intro 0:00 – 1:30, Outro 20:00 – 24:00',
+    })
 
     const regions = Array.from(timeline.children) as Array<HTMLElement>
     expect(regions).toHaveLength(2)
@@ -96,7 +95,7 @@ describe('SegmentTimeline', () => {
       <SegmentTimeline segments={[segment(10, 11)]} runtimeSeconds={1440} />,
     )
 
-    const timeline = screen.getByTestId('segment-timeline')
+    const timeline = screen.getByRole('img')
     const regions = Array.from(timeline.children) as Array<HTMLElement>
     expect(regions).toHaveLength(1)
     expect(regions[0].style.width).toBe('0.8%')
@@ -110,10 +109,9 @@ describe('SegmentTimeline', () => {
       />,
     )
 
-    const timeline = screen.getByTestId('segment-timeline')
-    expect(timeline.getAttribute('aria-label')).toBe(
-      'Segments: Zusammenfassung 0:10 – 1:00',
-    )
+    const timeline = screen.getByRole('img', {
+      name: 'Segments: Zusammenfassung 0:10 – 1:00',
+    })
 
     const regions = Array.from(timeline.children) as Array<HTMLElement>
     expect(regions[0].title).toBe('Zusammenfassung 0:10 – 1:00')
@@ -122,16 +120,19 @@ describe('SegmentTimeline', () => {
   it('renders an empty labelled track when no segments exist', () => {
     render(<SegmentTimeline segments={[]} runtimeSeconds={1440} />)
 
-    const timeline = screen.getByTestId('segment-timeline')
-    expect(timeline.getAttribute('aria-label')).toBe('No segments')
+    const timeline = screen.getByRole('img', { name: 'No segments' })
     expect(timeline.children).toHaveLength(0)
   })
 
   it('renders a placeholder while loading', () => {
-    render(<SegmentTimeline segments={[]} runtimeSeconds={1440} isLoading />)
+    const { container } = render(
+      <SegmentTimeline segments={[]} runtimeSeconds={1440} isLoading />,
+    )
 
-    expect(screen.getByTestId('segment-timeline-loading')).toBeTruthy()
-    expect(screen.queryByTestId('segment-timeline')).toBeNull()
+    expect(screen.queryByRole('img')).toBeNull()
+    const placeholder = container.firstElementChild
+    expect(placeholder?.className).toContain('animate-pulse')
+    expect(placeholder?.getAttribute('aria-hidden')).toBe('true')
   })
 
   it('scales against the furthest segment end when runtime is unknown', () => {
@@ -142,7 +143,7 @@ describe('SegmentTimeline', () => {
       />,
     )
 
-    const timeline = screen.getByTestId('segment-timeline')
+    const timeline = screen.getByRole('img')
     const regions = Array.from(timeline.children) as Array<HTMLElement>
     expect(regions).toHaveLength(2)
     expect(regions[0].style.width).toBe('10%')

--- a/src/__tests__/segment-timeline.test.tsx
+++ b/src/__tests__/segment-timeline.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MediaSegmentDto } from '@/types/jellyfin'
+import { MediaSegmentType } from '@/types/jellyfin'
+import {
+  SegmentTimeline,
+  formatTimelineTime,
+} from '@/components/segment/SegmentTimeline'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { changeLanguage: vi.fn(), language: 'en-US' },
+    t: (_key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+      if (typeof fallbackOrOptions === 'string') return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === 'object') {
+        const { defaultValue, ...params } = fallbackOrOptions
+        let text = typeof defaultValue === 'string' ? defaultValue : _key
+        for (const [name, value] of Object.entries(params)) {
+          text = text.replace(`{{${name}}}`, String(value))
+        }
+        return text
+      }
+      return _key
+    },
+  }),
+}))
+
+// StartTicks/EndTicks are in SECONDS at the UI boundary (see segments/api.ts)
+const segment = (
+  start: number,
+  end: number,
+  type: MediaSegmentType = MediaSegmentType.Intro,
+  id = `seg-${type}-${start}`,
+): MediaSegmentDto => ({
+  Id: id,
+  ItemId: 'item-1',
+  Type: type,
+  StartTicks: start,
+  EndTicks: end,
+})
+
+describe('formatTimelineTime', () => {
+  it('formats minutes and hours without milliseconds', () => {
+    expect(formatTimelineTime(0)).toBe('0:00')
+    expect(formatTimelineTime(24.9)).toBe('0:24')
+    expect(formatTimelineTime(114)).toBe('1:54')
+    expect(formatTimelineTime(3665)).toBe('1:01:05')
+  })
+
+  it('falls back to 0:00 for invalid values', () => {
+    expect(formatTimelineTime(Number.NaN)).toBe('0:00')
+    expect(formatTimelineTime(-5)).toBe('0:00')
+  })
+})
+
+describe('SegmentTimeline', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders colored regions positioned by runtime percentage', () => {
+    render(
+      <SegmentTimeline
+        segments={[
+          segment(0, 90, MediaSegmentType.Intro),
+          segment(1200, 1440, MediaSegmentType.Outro),
+        ]}
+        runtimeSeconds={1440}
+      />,
+    )
+
+    const timeline = screen.getByTestId('segment-timeline')
+    expect(timeline.getAttribute('aria-label')).toBe(
+      'Segments: Intro 0:00 – 1:30, Outro 20:00 – 24:00',
+    )
+
+    const regions = Array.from(timeline.children) as Array<HTMLElement>
+    expect(regions).toHaveLength(2)
+
+    expect(regions[0].style.left).toBe('0%')
+    expect(regions[0].style.width).toBe('6.25%')
+    expect(regions[0].style.backgroundColor).toBe('var(--segment-intro)')
+    expect(regions[0].title).toBe('Intro 0:00 – 1:30')
+
+    expect(regions[1].style.left).toBe(`${(1200 / 1440) * 100}%`)
+    expect(regions[1].style.backgroundColor).toBe('var(--segment-outro)')
+  })
+
+  it('keeps very short segments visible', () => {
+    render(
+      <SegmentTimeline segments={[segment(10, 11)]} runtimeSeconds={1440} />,
+    )
+
+    const timeline = screen.getByTestId('segment-timeline')
+    const regions = Array.from(timeline.children) as Array<HTMLElement>
+    expect(regions).toHaveLength(1)
+    expect(regions[0].style.width).toBe('0.8%')
+  })
+
+  it('renders an empty labelled track when no segments exist', () => {
+    render(<SegmentTimeline segments={[]} runtimeSeconds={1440} />)
+
+    const timeline = screen.getByTestId('segment-timeline')
+    expect(timeline.getAttribute('aria-label')).toBe('No segments')
+    expect(timeline.children).toHaveLength(0)
+  })
+
+  it('renders a placeholder while loading', () => {
+    render(<SegmentTimeline segments={[]} runtimeSeconds={1440} isLoading />)
+
+    expect(screen.getByTestId('segment-timeline-loading')).toBeTruthy()
+    expect(screen.queryByTestId('segment-timeline')).toBeNull()
+  })
+
+  it('scales against the furthest segment end when runtime is unknown', () => {
+    render(
+      <SegmentTimeline
+        segments={[segment(0, 60), segment(540, 600, MediaSegmentType.Outro)]}
+        runtimeSeconds={0}
+      />,
+    )
+
+    const timeline = screen.getByTestId('segment-timeline')
+    const regions = Array.from(timeline.children) as Array<HTMLElement>
+    expect(regions).toHaveLength(2)
+    expect(regions[0].style.width).toBe('10%')
+    expect(regions[1].style.left).toBe('90%')
+  })
+})

--- a/src/__tests__/segment-timeline.test.tsx
+++ b/src/__tests__/segment-timeline.test.tsx
@@ -7,10 +7,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import { MediaSegmentType } from '@/types/jellyfin'
-import {
-  SegmentTimeline,
-  formatTimelineTime,
-} from '@/components/segment/SegmentTimeline'
+import { SegmentTimeline } from '@/components/segment/SegmentTimeline'
+import { formatCompactTime } from '@/lib/time-utils'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -44,17 +42,17 @@ const segment = (
   EndTicks: end,
 })
 
-describe('formatTimelineTime', () => {
+describe('formatCompactTime', () => {
   it('formats minutes and hours without milliseconds', () => {
-    expect(formatTimelineTime(0)).toBe('0:00')
-    expect(formatTimelineTime(24.9)).toBe('0:24')
-    expect(formatTimelineTime(114)).toBe('1:54')
-    expect(formatTimelineTime(3665)).toBe('1:01:05')
+    expect(formatCompactTime(0)).toBe('0:00')
+    expect(formatCompactTime(24.9)).toBe('0:24')
+    expect(formatCompactTime(114)).toBe('1:54')
+    expect(formatCompactTime(3665)).toBe('1:01:05')
   })
 
   it('falls back to 0:00 for invalid values', () => {
-    expect(formatTimelineTime(Number.NaN)).toBe('0:00')
-    expect(formatTimelineTime(-5)).toBe('0:00')
+    expect(formatCompactTime(Number.NaN)).toBe('0:00')
+    expect(formatCompactTime(-5)).toBe('0:00')
   })
 })
 

--- a/src/__tests__/series-view.test.tsx
+++ b/src/__tests__/series-view.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BaseItemDto } from '@/types/jellyfin'
+import { SeriesView } from '@/components/views/SeriesView'
+
+const navigateMock = vi.hoisted(() => vi.fn())
+const observerRefMock = vi.hoisted(() => vi.fn())
+const segmentTimelineMock = vi.hoisted(() => vi.fn(() => null))
+const segmentsOptionsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/services/items/queries', () => ({
+  useEpisodes: () => ({
+    data: [
+      {
+        Id: 'episode-1',
+        Name: 'Episode 1',
+        ParentIndexNumber: 1,
+        IndexNumber: 1,
+        RunTimeTicks: 600_000_000,
+      },
+    ],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('@/services/segments/queries', () => ({
+  useSegments: (itemId: string, options: { enabled?: boolean }) => {
+    segmentsOptionsMock(itemId, options)
+    return { data: undefined, isPending: false, isError: true }
+  },
+}))
+
+vi.mock('@/hooks/use-in-view', () => ({
+  useInView: () => ({ ref: observerRefMock, inView: false }),
+}))
+
+vi.mock('@/components/media/ItemImage', () => ({
+  ItemImage: () => null,
+}))
+
+vi.mock('@/components/segment/SegmentTimeline', () => ({
+  SegmentTimeline: segmentTimelineMock,
+}))
+
+vi.mock('@/components/ui/interactive-card', () => ({
+  InteractiveCard: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+const series: BaseItemDto = { Id: 'series-1', Name: 'Series' }
+const season: BaseItemDto = {
+  Id: 'season-1',
+  Name: 'Season 1',
+  IndexNumber: 1,
+}
+
+describe('SeriesView', () => {
+  afterEach(() => {
+    cleanup()
+    navigateMock.mockReset()
+    observerRefMock.mockReset()
+    segmentTimelineMock.mockClear()
+    segmentsOptionsMock.mockReset()
+  })
+
+  it('keeps the lazy observer target mounted for a cached segment error', () => {
+    render(
+      <SeriesView
+        series={series}
+        seasons={[season]}
+        selectedSeasonId="season-1"
+        onSeasonSelect={vi.fn()}
+      />,
+    )
+
+    expect(segmentsOptionsMock).toHaveBeenCalledWith('episode-1', {
+      enabled: false,
+    })
+    expect(observerRefMock).toHaveBeenCalledWith(expect.any(HTMLDivElement))
+    expect(segmentTimelineMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/use-in-view.test.tsx
+++ b/src/__tests__/use-in-view.test.tsx
@@ -9,9 +9,7 @@ import { useInView } from '@/hooks/use-in-view'
 
 function Probe({ rootMargin }: { rootMargin?: string }) {
   const { ref, inView } = useInView<HTMLDivElement>({ rootMargin })
-  return (
-    <div ref={ref} data-testid="probe" data-inview={inView ? 'yes' : 'no'} />
-  )
+  return <div ref={ref}>{inView ? 'visible' : 'hidden'}</div>
 }
 
 type ObserverCallback = (entries: Array<{ isIntersecting: boolean }>) => void
@@ -56,15 +54,14 @@ describe('useInView', () => {
     // jsdom has no IntersectionObserver by default
     render(<Probe />)
 
-    expect(screen.getByTestId('probe').dataset.inview).toBe('yes')
+    expect(screen.getByText('visible')).toBeTruthy()
   })
 
   it('stays hidden until the element intersects, then latches', () => {
     installMockObserver()
     render(<Probe rootMargin="600px 0px" />)
 
-    const probe = screen.getByTestId('probe')
-    expect(probe.dataset.inview).toBe('no')
+    const probe = screen.getByText('hidden')
 
     const observer = MockIntersectionObserver.instances[0]
     expect(observer.options?.rootMargin).toBe('600px 0px')
@@ -73,12 +70,12 @@ describe('useInView', () => {
     act(() => {
       observer.callback([{ isIntersecting: false }])
     })
-    expect(probe.dataset.inview).toBe('no')
+    expect(probe.textContent).toBe('hidden')
 
     act(() => {
       observer.callback([{ isIntersecting: true }])
     })
-    expect(probe.dataset.inview).toBe('yes')
+    expect(probe.textContent).toBe('visible')
     expect(observer.disconnected).toBe(true)
 
     // Latch: no further observation once visible

--- a/src/__tests__/use-in-view.test.tsx
+++ b/src/__tests__/use-in-view.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useInView } from '@/hooks/use-in-view'
+
+function Probe({ rootMargin }: { rootMargin?: string }) {
+  const { ref, inView } = useInView<HTMLDivElement>({ rootMargin })
+  return (
+    <div ref={ref} data-testid="probe" data-inview={inView ? 'yes' : 'no'} />
+  )
+}
+
+type ObserverCallback = (entries: Array<{ isIntersecting: boolean }>) => void
+
+class MockIntersectionObserver {
+  static instances: Array<MockIntersectionObserver> = []
+  callback: ObserverCallback
+  options?: IntersectionObserverInit
+  observed: Array<Element> = []
+  disconnected = false
+
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback
+    this.options = options
+    MockIntersectionObserver.instances.push(this)
+  }
+
+  observe(element: Element) {
+    this.observed.push(element)
+  }
+
+  disconnect() {
+    this.disconnected = true
+  }
+
+  unobserve() {}
+}
+
+const installMockObserver = () => {
+  MockIntersectionObserver.instances = []
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+}
+
+describe('useInView', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    MockIntersectionObserver.instances = []
+  })
+
+  it('falls back to visible when IntersectionObserver is unavailable', () => {
+    // jsdom has no IntersectionObserver by default
+    render(<Probe />)
+
+    expect(screen.getByTestId('probe').dataset.inview).toBe('yes')
+  })
+
+  it('stays hidden until the element intersects, then latches', () => {
+    installMockObserver()
+    render(<Probe rootMargin="600px 0px" />)
+
+    const probe = screen.getByTestId('probe')
+    expect(probe.dataset.inview).toBe('no')
+
+    const observer = MockIntersectionObserver.instances[0]
+    expect(observer.options?.rootMargin).toBe('600px 0px')
+    expect(observer.observed).toContain(probe)
+
+    act(() => {
+      observer.callback([{ isIntersecting: false }])
+    })
+    expect(probe.dataset.inview).toBe('no')
+
+    act(() => {
+      observer.callback([{ isIntersecting: true }])
+    })
+    expect(probe.dataset.inview).toBe('yes')
+    expect(observer.disconnected).toBe(true)
+
+    // Latch: no further observation once visible
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+  })
+})

--- a/src/components/player/PlayerScrubber.tsx
+++ b/src/components/player/PlayerScrubber.tsx
@@ -3,10 +3,11 @@ import { useTranslation } from 'react-i18next'
 
 import type { ChapterInfo, MediaSegmentDto } from '@/types/jellyfin'
 import type { TrickplayData, TrickplayPosition } from '@/lib/trickplay-utils'
+import type { SegmentRegion } from '@/lib/segment-utils'
 import { cn } from '@/lib/utils'
 import { formatTime, ticksToSeconds } from '@/lib/time-utils'
 import { handleRangeKeyboard } from '@/lib/range-keyboard'
-import { DEFAULT_SEGMENT_COLOR, SEGMENT_COLORS } from '@/lib/constants'
+import { getSegmentRegions } from '@/lib/segment-utils'
 import {
   getBestTrickplayInfo,
   getTrickplayPosition,
@@ -50,14 +51,6 @@ interface ChapterMarker {
   time: number
 }
 
-interface SegmentRegion {
-  id: MediaSegmentDto['Id']
-  type: MediaSegmentDto['Type']
-  start: number
-  width: number
-  color: string
-}
-
 function getChapterMarkers(
   chapters: Array<ChapterInfo> | null | undefined,
   duration: number,
@@ -77,37 +70,6 @@ function getChapterMarkers(
     }
   }
   return markers
-}
-
-function getSegmentRegions(
-  segments: Array<MediaSegmentDto> | undefined,
-  duration: number,
-): Array<SegmentRegion> {
-  if (!segments || segments.length === 0 || duration <= 0) return []
-
-  const regions: Array<SegmentRegion> = []
-  for (const segment of segments) {
-    const startSeconds = segment.StartTicks ?? 0
-    const startPercent = (startSeconds / duration) * 100
-    if (startPercent >= 100) continue
-    const endSeconds = segment.EndTicks ?? 0
-    const endPercent = (endSeconds / duration) * 100
-    const clampedStart = Math.max(0, startPercent)
-    const clampedEnd = Math.min(100, endPercent)
-    const width = Math.max(0, clampedEnd - clampedStart)
-    if (width <= 0.1) continue
-    const colorConfig = segment.Type
-      ? SEGMENT_COLORS[segment.Type]
-      : DEFAULT_SEGMENT_COLOR
-    regions.push({
-      id: segment.Id,
-      type: segment.Type,
-      start: clampedStart,
-      width,
-      color: colorConfig.css,
-    })
-  }
-  return regions
 }
 
 function ScrubberTrack({

--- a/src/components/segment/SegmentTimeline.tsx
+++ b/src/components/segment/SegmentTimeline.tsx
@@ -1,0 +1,113 @@
+/**
+ * SegmentTimeline component.
+ * Read-only miniature timeline showing which segments exist across an
+ * item's runtime, mirroring the segment colors used by the player scrubber
+ * and editor. Designed for list views (e.g. episode lists) so segment
+ * coverage is visible at a glance without opening the editor.
+ */
+
+import { useTranslation } from 'react-i18next'
+
+import type { MediaSegmentDto } from '@/types/jellyfin'
+import type { SegmentRegion } from '@/lib/segment-utils'
+import { getSegmentRegions } from '@/lib/segment-utils'
+import { cn } from '@/lib/utils'
+
+/**
+ * Minimum rendered region width in percent. Keeps short segments (e.g. a
+ * few seconds of preview) visible on narrow tracks instead of dropping them.
+ */
+const MIN_VISIBLE_WIDTH_PERCENT = 0.8
+
+/** Formats seconds as m:ss or h:mm:ss for tooltips and accessible labels */
+export function formatTimelineTime(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0
+  const hours = Math.floor(safe / 3600)
+  const minutes = Math.floor((safe % 3600) / 60)
+  const secs = safe % 60
+  const ss = String(secs).padStart(2, '0')
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${ss}`
+  }
+  return `${minutes}:${ss}`
+}
+
+const formatRegionRange = (region: SegmentRegion): string =>
+  `${region.type ?? 'Unknown'} ${formatTimelineTime(region.startSeconds)} – ${formatTimelineTime(region.endSeconds)}`
+
+interface SegmentTimelineProps {
+  /** Segments with StartTicks/EndTicks in seconds (as returned by useSegments) */
+  segments: Array<MediaSegmentDto>
+  /** Total runtime of the item in seconds */
+  runtimeSeconds: number
+  /** Renders a pulsing placeholder track while segment data loads */
+  isLoading?: boolean
+  className?: string
+}
+
+export function SegmentTimeline({
+  segments,
+  runtimeSeconds,
+  isLoading = false,
+  className,
+}: SegmentTimelineProps) {
+  const { t } = useTranslation()
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn(
+          'h-1.5 rounded-full bg-muted/70 animate-pulse',
+          className,
+        )}
+        aria-hidden="true"
+        data-testid="segment-timeline-loading"
+      />
+    )
+  }
+
+  // Fall back to the furthest segment end so existing segments still render
+  // (with correct relative placement) when the item has no known runtime.
+  const maxSegmentEnd = segments.reduce(
+    (max, segment) => Math.max(max, segment.EndTicks ?? 0),
+    0,
+  )
+  const duration = runtimeSeconds > 0 ? runtimeSeconds : maxSegmentEnd
+  const regions = getSegmentRegions(segments, duration, {
+    minVisibleWidthPercent: MIN_VISIBLE_WIDTH_PERCENT,
+  })
+
+  const label =
+    regions.length === 0
+      ? t('segment.timeline.empty', 'No segments')
+      : t('segment.timeline.label', {
+          defaultValue: 'Segments: {{list}}',
+          list: regions.map(formatRegionRange).join(', '),
+        })
+
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      data-testid="segment-timeline"
+      className={cn(
+        'relative h-1.5 rounded-full overflow-hidden bg-primary/15',
+        className,
+      )}
+    >
+      {regions.map((region) => (
+        <div
+          key={region.id}
+          className="absolute inset-y-0 opacity-90"
+          style={{
+            left: `${region.start}%`,
+            width: `${region.width}%`,
+            backgroundColor: region.color,
+          }}
+          title={formatRegionRange(region)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/segment/SegmentTimeline.tsx
+++ b/src/components/segment/SegmentTimeline.tsx
@@ -20,9 +20,6 @@ import { cn } from '@/lib/utils'
  */
 const MIN_VISIBLE_WIDTH_PERCENT = 0.8
 
-const formatRegionRange = (typeLabel: string, region: SegmentRegion): string =>
-  `${typeLabel} ${formatCompactTime(region.startSeconds)} – ${formatCompactTime(region.endSeconds)}`
-
 interface SegmentTimelineProps {
   /** Segments with StartTicks/EndTicks in seconds (as returned by useSegments) */
   segments: Array<MediaSegmentDto>
@@ -45,7 +42,7 @@ export function SegmentTimeline({
   // values fall back to the raw type string.
   const regionLabel = (region: SegmentRegion): string => {
     const type = region.type ?? 'Unknown'
-    return formatRegionRange(t(`segmentType.${type}`, type), region)
+    return `${t(`segmentType.${type}`, type)} ${formatCompactTime(region.startSeconds)} – ${formatCompactTime(region.endSeconds)}`
   }
 
   if (isLoading) {
@@ -56,7 +53,6 @@ export function SegmentTimeline({
           className,
         )}
         aria-hidden="true"
-        data-testid="segment-timeline-loading"
       />
     )
   }
@@ -84,7 +80,6 @@ export function SegmentTimeline({
     <div
       role="img"
       aria-label={label}
-      data-testid="segment-timeline"
       className={cn(
         'relative h-1.5 rounded-full overflow-hidden bg-primary/15',
         className,

--- a/src/components/segment/SegmentTimeline.tsx
+++ b/src/components/segment/SegmentTimeline.tsx
@@ -20,8 +20,8 @@ import { cn } from '@/lib/utils'
  */
 const MIN_VISIBLE_WIDTH_PERCENT = 0.8
 
-const formatRegionRange = (region: SegmentRegion): string =>
-  `${region.type ?? 'Unknown'} ${formatCompactTime(region.startSeconds)} – ${formatCompactTime(region.endSeconds)}`
+const formatRegionRange = (typeLabel: string, region: SegmentRegion): string =>
+  `${typeLabel} ${formatCompactTime(region.startSeconds)} – ${formatCompactTime(region.endSeconds)}`
 
 interface SegmentTimelineProps {
   /** Segments with StartTicks/EndTicks in seconds (as returned by useSegments) */
@@ -40,6 +40,13 @@ export function SegmentTimeline({
   className,
 }: SegmentTimelineProps) {
   const { t } = useTranslation()
+
+  // Localized like SegmentSlider/SegmentTypeMenu; unknown server enum
+  // values fall back to the raw type string.
+  const regionLabel = (region: SegmentRegion): string => {
+    const type = region.type ?? 'Unknown'
+    return formatRegionRange(t(`segmentType.${type}`, type), region)
+  }
 
   if (isLoading) {
     return (
@@ -70,7 +77,7 @@ export function SegmentTimeline({
       ? t('segment.timeline.empty', 'No segments')
       : t('segment.timeline.label', {
           defaultValue: 'Segments: {{list}}',
-          list: regions.map(formatRegionRange).join(', '),
+          list: regions.map(regionLabel).join(', '),
         })
 
   return (
@@ -92,7 +99,7 @@ export function SegmentTimeline({
             width: `${region.width}%`,
             backgroundColor: region.color,
           }}
-          title={formatRegionRange(region)}
+          title={regionLabel(region)}
         />
       ))}
     </div>

--- a/src/components/segment/SegmentTimeline.tsx
+++ b/src/components/segment/SegmentTimeline.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import type { MediaSegmentDto } from '@/types/jellyfin'
 import type { SegmentRegion } from '@/lib/segment-utils'
 import { getSegmentRegions } from '@/lib/segment-utils'
+import { formatCompactTime } from '@/lib/time-utils'
 import { cn } from '@/lib/utils'
 
 /**
@@ -19,22 +20,8 @@ import { cn } from '@/lib/utils'
  */
 const MIN_VISIBLE_WIDTH_PERCENT = 0.8
 
-/** Formats seconds as m:ss or h:mm:ss for tooltips and accessible labels */
-export function formatTimelineTime(seconds: number): string {
-  const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0
-  const hours = Math.floor(safe / 3600)
-  const minutes = Math.floor((safe % 3600) / 60)
-  const secs = safe % 60
-  const ss = String(secs).padStart(2, '0')
-
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${ss}`
-  }
-  return `${minutes}:${ss}`
-}
-
 const formatRegionRange = (region: SegmentRegion): string =>
-  `${region.type ?? 'Unknown'} ${formatTimelineTime(region.startSeconds)} – ${formatTimelineTime(region.endSeconds)}`
+  `${region.type ?? 'Unknown'} ${formatCompactTime(region.startSeconds)} – ${formatCompactTime(region.endSeconds)}`
 
 interface SegmentTimelineProps {
   /** Segments with StartTicks/EndTicks in seconds (as returned by useSegments) */

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -107,17 +107,19 @@ function EpisodeSegmentTimeline({
     isError,
   } = useSegments(episodeId, { enabled: inView })
 
-  // useSegments disables the query for an empty id; bail out so those
-  // episodes render nothing instead of a perpetual loading placeholder.
-  if (!episodeId || isError) return null
+  // Keep the observer target mounted for cached errors so entering the
+  // viewport can re-enable the query and retry it.
+  if (!episodeId) return null
 
   return (
     <div ref={ref} className="mt-2 md:mt-2.5">
-      <SegmentTimeline
-        segments={segments ?? []}
-        runtimeSeconds={runtimeSeconds}
-        isLoading={isPending}
-      />
+      {!isError && (
+        <SegmentTimeline
+          segments={segments ?? []}
+          runtimeSeconds={runtimeSeconds}
+          isLoading={isPending}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -90,12 +90,10 @@ function EpisodeSegmentTimeline({
   episodeId,
   runtimeSeconds,
 }: EpisodeSegmentTimelineProps) {
-  const {
-    data: segments,
-    isPending,
-    isError,
-  } = useSegments(episodeId, { enabled: !!episodeId })
+  const { data: segments, isPending, isError } = useSegments(episodeId)
 
+  // useSegments disables the query for an empty id; bail out so those
+  // episodes render nothing instead of a perpetual loading placeholder.
   if (!episodeId || isError) return null
 
   return (

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -4,12 +4,15 @@ import { AlertCircle, Play } from 'lucide-react'
 
 import type { BaseItemDto } from '@/types/jellyfin'
 import { useEpisodes } from '@/services/items/queries'
+import { useSegments } from '@/services/segments/queries'
 import { ItemImage } from '@/components/media/ItemImage'
+import { SegmentTimeline } from '@/components/segment/SegmentTimeline'
 import { InteractiveCard } from '@/components/ui/interactive-card'
 import { LoadingState } from '@/components/ui/async-state'
 import { EmptyState } from '@/components/ui/empty-state'
 import { ErrorState } from '@/components/ui/error-state'
 import { cn } from '@/lib/utils'
+import { ticksToSeconds } from '@/lib/time-utils'
 import { staggerDelay, STAGGER_NORMAL } from '@/lib/animation-utils'
 
 interface SeriesViewProps {
@@ -75,6 +78,33 @@ const SeasonTabs = function SeasonTabsComponent({
         )
       })}
     </div>
+  )
+}
+
+interface EpisodeSegmentTimelineProps {
+  episodeId: string
+  runtimeSeconds: number
+}
+
+function EpisodeSegmentTimeline({
+  episodeId,
+  runtimeSeconds,
+}: EpisodeSegmentTimelineProps) {
+  const {
+    data: segments,
+    isPending,
+    isError,
+  } = useSegments(episodeId, { enabled: !!episodeId })
+
+  if (!episodeId || isError) return null
+
+  return (
+    <SegmentTimeline
+      segments={segments ?? []}
+      runtimeSeconds={runtimeSeconds}
+      isLoading={isPending}
+      className="mt-2 md:mt-2.5"
+    />
   )
 }
 
@@ -144,6 +174,10 @@ const EpisodeCard = function EpisodeCardComponent({
           {episode.Name ? episodeLabel : t('series.episode')}
           {runtime && ` · ${runtime} min`}
         </p>
+        <EpisodeSegmentTimeline
+          episodeId={episodeId}
+          runtimeSeconds={ticksToSeconds(episode.RunTimeTicks)}
+        />
       </div>
     </InteractiveCard>
   )

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, Play } from 'lucide-react'
 import type { BaseItemDto } from '@/types/jellyfin'
 import { useEpisodes } from '@/services/items/queries'
 import { useSegments } from '@/services/segments/queries'
+import { useInView } from '@/hooks/use-in-view'
 import { ItemImage } from '@/components/media/ItemImage'
 import { SegmentTimeline } from '@/components/segment/SegmentTimeline'
 import { InteractiveCard } from '@/components/ui/interactive-card'
@@ -86,23 +87,38 @@ interface EpisodeSegmentTimelineProps {
   runtimeSeconds: number
 }
 
+/**
+ * Prefetch margin for per-episode segment queries. Rows within this distance
+ * of the viewport start fetching, so bars are ready as the user scrolls
+ * while off-screen rows of large seasons don't fire requests on mount.
+ */
+const SEGMENT_PREFETCH_ROOT_MARGIN = '600px 0px'
+
 function EpisodeSegmentTimeline({
   episodeId,
   runtimeSeconds,
 }: EpisodeSegmentTimelineProps) {
-  const { data: segments, isPending, isError } = useSegments(episodeId)
+  const { ref, inView } = useInView<HTMLDivElement>({
+    rootMargin: SEGMENT_PREFETCH_ROOT_MARGIN,
+  })
+  const {
+    data: segments,
+    isPending,
+    isError,
+  } = useSegments(episodeId, { enabled: inView })
 
   // useSegments disables the query for an empty id; bail out so those
   // episodes render nothing instead of a perpetual loading placeholder.
   if (!episodeId || isError) return null
 
   return (
-    <SegmentTimeline
-      segments={segments ?? []}
-      runtimeSeconds={runtimeSeconds}
-      isLoading={isPending}
-      className="mt-2 md:mt-2.5"
-    />
+    <div ref={ref} className="mt-2 md:mt-2.5">
+      <SegmentTimeline
+        segments={segments ?? []}
+        runtimeSeconds={runtimeSeconds}
+        isLoading={isPending}
+      />
+    </div>
   )
 }
 

--- a/src/hooks/use-in-view.ts
+++ b/src/hooks/use-in-view.ts
@@ -1,0 +1,54 @@
+/**
+ * Latching viewport-visibility hook.
+ * Reports when an element first enters (or nears, via rootMargin) the
+ * viewport, then stays true and stops observing. Used to defer per-item
+ * network requests in long lists until rows approach the viewport.
+ *
+ * Falls back to immediately visible when IntersectionObserver is
+ * unavailable (older browsers, non-DOM test environments).
+ */
+
+import * as React from 'react'
+
+interface UseInViewOptions {
+  /** Margin around the viewport used for early triggering (e.g. '600px 0px') */
+  rootMargin?: string
+}
+
+interface UseInViewReturn<T extends Element> {
+  ref: React.RefObject<T | null>
+  inView: boolean
+}
+
+export function useInView<T extends Element>(
+  options?: UseInViewOptions,
+): UseInViewReturn<T> {
+  const ref = React.useRef<T | null>(null)
+  // Fall back to immediately visible when IntersectionObserver is missing
+  const [inView, setInView] = React.useState(
+    () => typeof IntersectionObserver === 'undefined',
+  )
+  const rootMargin = options?.rootMargin ?? '0px'
+
+  React.useEffect(() => {
+    if (inView) return
+
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setInView(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin },
+    )
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [inView, rootMargin])
+
+  return { ref, inView }
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -190,7 +190,11 @@
     "sliderGroup": "{{type}} Segment Bereichsregler",
     "sliderDescription": "{{type}} Segment von {{start}} bis {{end}}, Dauer {{duration}}. Verwende Pfeiltasten zum Anpassen.",
     "startHandle": "{{type}} Segment Startgriff",
-    "endHandle": "{{type}} Segment Endgriff"
+    "endHandle": "{{type}} Segment Endgriff",
+    "timeline": {
+      "label": "Segmente: {{list}}",
+      "empty": "Keine Segmente"
+    }
   },
   "validation": {
     "StartEnd": "Start liegt immer vor dem Ende"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -190,7 +190,11 @@
     "sliderGroup": "{{type}} segment range slider",
     "sliderDescription": "{{type}} segment from {{start}} to {{end}}, duration {{duration}}. Use arrow keys to adjust handles.",
     "startHandle": "{{type}} segment start handle",
-    "endHandle": "{{type}} segment end handle"
+    "endHandle": "{{type}} segment end handle",
+    "timeline": {
+      "label": "Segments: {{list}}",
+      "empty": "No segments"
+    }
   },
   "validation": {
     "StartEnd": "Start is always before End"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -133,7 +133,11 @@
     "sliderGroup": "Curseur de plage du segment {{type}}",
     "sliderDescription": "Segment {{type}} de {{start}} à {{end}}, durée {{duration}}. Utilisez les touches fléchées pour ajuster.",
     "startHandle": "Poignée de début du segment {{type}}",
-    "endHandle": "Poignée de fin du segment {{type}}"
+    "endHandle": "Poignée de fin du segment {{type}}",
+    "timeline": {
+      "label": "Segments : {{list}}",
+      "empty": "Aucun segment"
+    }
   },
   "validation": {
     "StartEnd": "Le début est toujours avant la fin"

--- a/src/lib/segment-utils.ts
+++ b/src/lib/segment-utils.ts
@@ -98,6 +98,85 @@ export const getSegmentColor = (type: MediaSegmentType | undefined): string =>
 export const getSegmentCssVar = (type: MediaSegmentType | undefined): string =>
   (type && SEGMENT_COLORS[type].css) ?? DEFAULT_SEGMENT_COLOR.css
 
+/**
+ * A segment mapped to percent-based track coordinates for timeline rendering.
+ * Shared by the player scrubber and the read-only episode-list timeline.
+ */
+export interface SegmentRegion {
+  id: MediaSegmentDto['Id']
+  type: MediaSegmentDto['Type']
+  /** Left edge as percent of track width [0, 100] */
+  start: number
+  /** Width as percent of track width [0, 100] */
+  width: number
+  /** CSS color value for the segment type */
+  color: string
+  /** Segment start in seconds, clamped to [0, duration] */
+  startSeconds: number
+  /** Segment end in seconds, clamped to [0, duration] */
+  endSeconds: number
+}
+
+export interface SegmentRegionOptions {
+  /**
+   * Minimum rendered width in percent. Regions narrower than this are
+   * widened to stay visible (shifted left when they would overflow the
+   * track). Without this option, regions narrower than 0.1% are dropped,
+   * which matches the player scrubber's historical behavior.
+   */
+  minVisibleWidthPercent?: number
+}
+
+/**
+ * Maps segments (times in seconds) onto percent-based track regions.
+ * Segments outside [0, duration] are clamped; degenerate spans are dropped.
+ */
+export const getSegmentRegions = (
+  segments: Array<MediaSegmentDto> | undefined,
+  duration: number,
+  options?: SegmentRegionOptions,
+): Array<SegmentRegion> => {
+  if (!segments || segments.length === 0 || duration <= 0) return []
+
+  const minVisibleWidth = options?.minVisibleWidthPercent
+  const regions: Array<SegmentRegion> = []
+  for (const segment of segments) {
+    const startSeconds = segment.StartTicks ?? 0
+    const startPercent = (startSeconds / duration) * 100
+    if (startPercent >= 100) continue
+    const endSeconds = segment.EndTicks ?? 0
+    const endPercent = (endSeconds / duration) * 100
+    const clampedStart = Math.max(0, startPercent)
+    const clampedEnd = Math.min(100, endPercent)
+    let width = Math.max(0, clampedEnd - clampedStart)
+    let left = clampedStart
+
+    if (minVisibleWidth === undefined) {
+      if (width <= 0.1) continue
+    } else {
+      if (width <= 0) continue
+      if (width < minVisibleWidth) {
+        width = Math.min(minVisibleWidth, 100)
+        left = Math.min(clampedStart, 100 - width)
+      }
+    }
+
+    const colorConfig = segment.Type
+      ? SEGMENT_COLORS[segment.Type]
+      : DEFAULT_SEGMENT_COLOR
+    regions.push({
+      id: segment.Id,
+      type: segment.Type,
+      start: left,
+      width,
+      color: colorConfig.css,
+      startSeconds: Math.max(0, Math.min(startSeconds, duration)),
+      endSeconds: Math.max(0, Math.min(endSeconds, duration)),
+    })
+  }
+  return regions
+}
+
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 

--- a/src/lib/segment-utils.ts
+++ b/src/lib/segment-utils.ts
@@ -92,11 +92,26 @@ export const resolveSegmentIndex = (
   return ref.index >= 0 && ref.index < segments.length ? ref.index : -1
 }
 
+type SegmentColorConfig = (typeof SEGMENT_COLORS)[MediaSegmentType]
+
+/**
+ * Runtime-safe color lookup. Segment data comes from the server, which may
+ * report enum values this client doesn't know yet (newer Jellyfin versions);
+ * those fall back to the default color instead of crashing the render.
+ */
+const getSegmentColorConfig = (
+  type: MediaSegmentType | undefined,
+): SegmentColorConfig => {
+  if (!type) return DEFAULT_SEGMENT_COLOR
+  const config = SEGMENT_COLORS[type] as SegmentColorConfig | undefined
+  return config ?? DEFAULT_SEGMENT_COLOR
+}
+
 export const getSegmentColor = (type: MediaSegmentType | undefined): string =>
-  (type && SEGMENT_COLORS[type].bg) ?? DEFAULT_SEGMENT_COLOR.bg
+  getSegmentColorConfig(type).bg
 
 export const getSegmentCssVar = (type: MediaSegmentType | undefined): string =>
-  (type && SEGMENT_COLORS[type].css) ?? DEFAULT_SEGMENT_COLOR.css
+  getSegmentColorConfig(type).css
 
 /**
  * A segment mapped to percent-based track coordinates for timeline rendering.
@@ -161,15 +176,12 @@ export const getSegmentRegions = (
       }
     }
 
-    const colorConfig = segment.Type
-      ? SEGMENT_COLORS[segment.Type]
-      : DEFAULT_SEGMENT_COLOR
     regions.push({
       id: segment.Id,
       type: segment.Type,
       start: left,
       width,
-      color: colorConfig.css,
+      color: getSegmentColorConfig(segment.Type).css,
       startSeconds: Math.max(0, Math.min(startSeconds, duration)),
       endSeconds: Math.max(0, Math.min(endSeconds, duration)),
     })

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -118,6 +118,26 @@ export function formatReadableTime(timeInSeconds: number): string {
   return parts.join(' ')
 }
 
+/**
+ * Formats seconds as a compact clock time like '1:54' or '1:01:05'
+ * (no milliseconds). Returns '0:00' for invalid inputs.
+ * @param timeInSeconds - Time value in seconds
+ * @returns Compact clock time string
+ */
+export function formatCompactTime(timeInSeconds: number): string {
+  const time = Math.floor(clampToTimeRange(timeInSeconds))
+
+  const hours = Math.floor(time / 3600)
+  const minutes = Math.floor((time % 3600) / 60)
+  const seconds = time % 60
+  const ss = String(seconds).padStart(2, '0')
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${ss}`
+  }
+  return `${minutes}:${ss}`
+}
+
 /** Time multipliers: [seconds, minutes, hours] */
 const TIME_MULTIPLIERS = [1, 60, 3600] as const
 


### PR DESCRIPTION
## Summary

Implements #179: each episode card in the series view now shows a thin read-only timeline bar with existing segments rendered as colored regions (same colors as the editor and player scrubber), so you can see at a glance which episodes already have intro/outro/recap segments — and which still need attention — without opening the editor for each one.

![Episode list with segment timelines](https://github.com/user-attachments/assets/184c123b-e0e0-4896-abf8-73537875cbc3)

## Changes

- **`src/lib/segment-utils.ts`** — extracted `getSegmentRegions` (segment → percent-based track region math) from `PlayerScrubber` into the shared segment utils so the scrubber and the new timeline share one implementation. Regions now also carry clamped `startSeconds`/`endSeconds` for tooltips/labels. New optional `minVisibleWidthPercent` widens very short segments instead of dropping them (default behavior unchanged for the scrubber).
- **`src/components/segment/SegmentTimeline.tsx`** (new) — read-only miniature timeline: colored regions positioned by runtime percentage, native tooltip per region (`Intro 0:24 – 1:54`, seconds precision), `role="img"` with a translated aria label listing all segments (or "No segments"), pulsing placeholder while loading. Falls back to the furthest segment end when an item has no known runtime so segments never silently disappear.
- **`src/components/views/SeriesView.tsx`** — each `EpisodeCard` fetches its segments via the existing `useSegments` hook (same query keys as the editor, so cached segments render instantly and editor saves invalidate the list automatically) and renders the timeline under the title. Hidden on fetch error to avoid per-card error noise.
- **i18n** — new `segment.timeline.label` / `segment.timeline.empty` keys in en-US, de, fr.

## Notes

- Jellyfin's MediaSegments API is per-item, so a season with N episodes issues N small GETs (one per card, deduped/cached by TanStack Query with the standard SHORT cache).
- An empty track (vs. loading shimmer) is deliberate signal: the episode has no segments yet.

## Testing

- `getSegmentRegions` unit tests: clamping, degenerate spans, default 0.1% drop behavior, min-width widening + right-edge shift, color fallback.
- `SegmentTimeline` component tests: region positions/colors/tooltips, empty + loading states, unknown-runtime fallback.
- Full suite: 70 files / 586 tests pass; `oxlint`, `oxfmt --check`, `tsc`, and `vite build` all clean.
- Verified visually against the bundled mock server: per-episode patterns render correctly, empty bars flag unsegmented episodes, tooltips show type + time range.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/1e095b3d-1039-4759-bf68-1dc5ddee7415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-094" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/1e095b3d-1039-4759-bf68-1dc5ddee7415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-094&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-094"><img alt="INTRO-094" src="https://capy.ai/api/badge/thread.svg?label=INTRO-094"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Add a read-only segment timeline to episode cards in the series view so users can see segment coverage at a glance.

New Features:
- Introduce a SegmentTimeline component that renders a miniature, read-only segment bar with colored regions and tooltips for each segment.
- Display the segment timeline under each episode card in the series view, driven by per-episode segment data.

Enhancements:
- Extract shared getSegmentRegions utilities for mapping media segments to percent-based track regions used by both the player scrubber and the new timeline.
- Enhance accessibility and localization of segment information via aria-labels and new i18n strings for segment timelines.

Tests:
- Add unit tests for getSegmentRegions covering clamping, minimal-width handling, and color fallback behavior.
- Add SegmentTimeline component tests for region rendering, accessibility labels, loading/empty states, and unknown-runtime fallback behavior.