### PR TITLE
fix(player): iPhone-safe fullscreen + guard view-transition abort rejections

### DIFF
--- a/src/__tests__/view-transition-error.test.ts
+++ b/src/__tests__/view-transition-error.test.ts
@@ -90,10 +90,7 @@ describe('createViewTransitionAbortHandler', () => {
 
 describe('installViewTransitionAbortHandler', () => {
   it('registers and removes the unhandledrejection listener', () => {
-    const originalWindow = Object.getOwnPropertyDescriptor(
-      globalThis,
-      'window',
-    )
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
     const addEventListener = vi.fn()
     const removeEventListener = vi.fn()
 

--- a/src/__tests__/view-transition-error.test.ts
+++ b/src/__tests__/view-transition-error.test.ts
@@ -33,7 +33,9 @@ describe('isViewTransitionAbortError', () => {
     ).toBe(true)
   })
 
-  it('matches the Chromium invalid state transition rejection', () => {
+  it('keeps Chromium invalid-state transition failures visible', () => {
+    // Chromium uses this generic rejection for real authoring defects such
+    // as duplicate view-transition-name values — it must not be suppressed.
     expect(
       isViewTransitionAbortError(
         new DOMException(
@@ -41,7 +43,7 @@ describe('isViewTransitionAbortError', () => {
           'InvalidStateError',
         ),
       ),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('ignores unrelated abort errors such as cancelled fetches', () => {

--- a/src/__tests__/view-transition-error.test.ts
+++ b/src/__tests__/view-transition-error.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createViewTransitionAbortHandler,
+  installViewTransitionAbortHandler,
+  isViewTransitionAbortError,
+} from '@/lib/view-transition-error'
+
+function createRejectionEvent(reason: unknown): PromiseRejectionEvent {
+  return {
+    reason,
+    preventDefault: vi.fn(),
+  } as unknown as PromiseRejectionEvent
+}
+
+describe('isViewTransitionAbortError', () => {
+  it('matches the WebKit view transition abort rejection', () => {
+    expect(
+      isViewTransitionAbortError(
+        new DOMException(
+          'Old view transition aborted by new view transition.',
+          'AbortError',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('matches the Chromium skipped transition rejection', () => {
+    expect(
+      isViewTransitionAbortError(
+        new DOMException('Transition was skipped', 'AbortError'),
+      ),
+    ).toBe(true)
+  })
+
+  it('matches the Chromium invalid state transition rejection', () => {
+    expect(
+      isViewTransitionAbortError(
+        new DOMException(
+          'Transition was aborted because of invalid state',
+          'InvalidStateError',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores unrelated abort errors such as cancelled fetches', () => {
+    expect(
+      isViewTransitionAbortError(
+        new DOMException('The operation was aborted.', 'AbortError'),
+      ),
+    ).toBe(false)
+  })
+
+  it('ignores non-DOMException reasons', () => {
+    expect(
+      isViewTransitionAbortError(new Error('Transition was skipped')),
+    ).toBe(false)
+    expect(isViewTransitionAbortError('Transition was skipped')).toBe(false)
+    expect(isViewTransitionAbortError(undefined)).toBe(false)
+  })
+})
+
+describe('createViewTransitionAbortHandler', () => {
+  it('prevents default handling for view transition aborts', () => {
+    const handler = createViewTransitionAbortHandler()
+    const event = createRejectionEvent(
+      new DOMException(
+        'Old view transition aborted by new view transition.',
+        'AbortError',
+      ),
+    )
+
+    handler(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves other rejections untouched', () => {
+    const handler = createViewTransitionAbortHandler()
+    const event = createRejectionEvent(new Error('network down'))
+
+    handler(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+})
+
+describe('installViewTransitionAbortHandler', () => {
+  it('registers and removes the unhandledrejection listener', () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'window',
+    )
+    const addEventListener = vi.fn()
+    const removeEventListener = vi.fn()
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { addEventListener, removeEventListener },
+    })
+
+    try {
+      const uninstall = installViewTransitionAbortHandler()
+
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+      expect(addEventListener).toHaveBeenCalledWith(
+        'unhandledrejection',
+        expect.any(Function),
+      )
+
+      const registeredHandler = addEventListener.mock.calls[0][1]
+
+      uninstall()
+
+      expect(removeEventListener).toHaveBeenCalledTimes(1)
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'unhandledrejection',
+        registeredHandler,
+      )
+    } finally {
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow)
+      } else {
+        delete (globalThis as { window?: unknown }).window
+      }
+    }
+  })
+})

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -54,15 +54,6 @@ import { extractTracks } from '@/services/video/tracks'
 
 const PLAYBACK_UPDATE_INTERVAL_MS = 120
 
-/**
- * iPhone Safari exposes no element fullscreen API (`Element.requestFullscreen`
- * exists on iPadOS/desktop but not iOS phones). The only fullscreen path there
- * is the WebKit-prefixed native video fullscreen method on the video element.
- */
-type WebkitFullscreenVideoElement = HTMLVideoElement & {
-  webkitEnterFullscreen?: () => void
-}
-
 function getPlaybackTimestampMs() {
   return performance.now()
 }
@@ -752,8 +743,12 @@ function useRenderPlayer({
     // iPhone Safari: no element fullscreen API, so calling
     // container.requestFullscreen() would throw synchronously. Fall back to
     // the native video fullscreen player instead.
-    const video = videoRef.current as WebkitFullscreenVideoElement | null
-    if (typeof video?.webkitEnterFullscreen === 'function') {
+    const video = videoRef.current
+    if (
+      video &&
+      'webkitEnterFullscreen' in video &&
+      typeof video.webkitEnterFullscreen === 'function'
+    ) {
       try {
         video.webkitEnterFullscreen()
       } catch {

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -54,6 +54,15 @@ import { extractTracks } from '@/services/video/tracks'
 
 const PLAYBACK_UPDATE_INTERVAL_MS = 120
 
+/**
+ * iPhone Safari exposes no element fullscreen API (`Element.requestFullscreen`
+ * exists on iPadOS/desktop but not iOS phones). The only fullscreen path there
+ * is the WebKit-prefixed native video fullscreen method on the video element.
+ */
+type WebkitFullscreenVideoElement = HTMLVideoElement & {
+  webkitEnterFullscreen?: () => void
+}
+
 function getPlaybackTimestampMs() {
   return performance.now()
 }
@@ -729,11 +738,28 @@ function useRenderPlayer({
         // Can fail if the document is not in fullscreen or element was removed.
         // The fullscreenchange listener will reconcile UI state regardless.
       })
-    } else {
+      return
+    }
+
+    if (typeof container.requestFullscreen === 'function') {
       container.requestFullscreen().catch(() => {
         // Can fail due to permissions policy, missing user gesture, or
         // element removal. UI state stays in sync via the fullscreenchange listener.
       })
+      return
+    }
+
+    // iPhone Safari: no element fullscreen API, so calling
+    // container.requestFullscreen() would throw synchronously. Fall back to
+    // the native video fullscreen player instead.
+    const video = videoRef.current as WebkitFullscreenVideoElement | null
+    if (typeof video?.webkitEnterFullscreen === 'function') {
+      try {
+        video.webkitEnterFullscreen()
+      } catch {
+        // Throws InvalidStateError when playback has not started yet;
+        // there is no fullscreen to enter in that case.
+      }
     }
   }
 

--- a/src/lib/view-transition-error.ts
+++ b/src/lib/view-transition-error.ts
@@ -1,0 +1,48 @@
+/**
+ * Suppresses unhandled promise rejections caused by aborted View Transitions.
+ *
+ * TanStack Router starts a view transition for every path-changing
+ * navigation. When a second navigation begins before the previous
+ * transition finished (e.g. the entry redirect in plugin mode), the browser
+ * aborts the old transition and rejects its pending promises. Nothing awaits
+ * those promises, so the rejection surfaces as an unhandled error:
+ * - WebKit: "AbortError: Old view transition aborted by new view transition."
+ * - Chromium: "AbortError: Transition was skipped"
+ * These rejections are an expected part of the View Transition lifecycle and
+ * must not reach global error reporting (e.g. the Jellyfin Web host page).
+ */
+
+const VIEW_TRANSITION_ABORT_PATTERNS = [
+  /view transition/i,
+  /transition was skipped/i,
+  /transition was aborted/i,
+]
+
+export function isViewTransitionAbortError(reason: unknown): boolean {
+  if (!(reason instanceof DOMException)) return false
+  if (reason.name !== 'AbortError' && reason.name !== 'InvalidStateError') {
+    return false
+  }
+  return VIEW_TRANSITION_ABORT_PATTERNS.some((pattern) =>
+    pattern.test(reason.message),
+  )
+}
+
+export function createViewTransitionAbortHandler(): (
+  event: PromiseRejectionEvent,
+) => void {
+  return (event) => {
+    if (isViewTransitionAbortError(event.reason)) {
+      event.preventDefault()
+    }
+  }
+}
+
+export function installViewTransitionAbortHandler(): () => void {
+  const handler = createViewTransitionAbortHandler()
+  window.addEventListener('unhandledrejection', handler)
+
+  return () => {
+    window.removeEventListener('unhandledrejection', handler)
+  }
+}

--- a/src/lib/view-transition-error.ts
+++ b/src/lib/view-transition-error.ts
@@ -1,28 +1,32 @@
 /**
- * Suppresses unhandled promise rejections caused by aborted View Transitions.
+ * Suppresses unhandled promise rejections caused by superseded View
+ * Transitions.
  *
  * TanStack Router starts a view transition for every path-changing
- * navigation. When a second navigation begins before the previous
- * transition finished (e.g. the entry redirect in plugin mode), the browser
- * aborts the old transition and rejects its pending promises. Nothing awaits
- * those promises, so the rejection surfaces as an unhandled error:
+ * navigation. When a second navigation begins before the previous transition
+ * finished, the browser aborts the old transition and rejects its pending
+ * promises. Nothing awaits those promises, so the rejection surfaces as an
+ * unhandled error:
  * - WebKit: "AbortError: Old view transition aborted by new view transition."
  * - Chromium: "AbortError: Transition was skipped"
  * These rejections are an expected part of the View Transition lifecycle and
  * must not reach global error reporting (e.g. the Jellyfin Web host page).
+ *
+ * Deliberately narrow: only `AbortError` supersession/skip messages are
+ * suppressed. Chromium reports genuine authoring defects (such as duplicate
+ * `view-transition-name` values) as `InvalidStateError: Transition was
+ * aborted because of invalid state`, which must stay visible to error
+ * reporting.
  */
 
 const VIEW_TRANSITION_ABORT_PATTERNS = [
   /view transition/i,
   /transition was skipped/i,
-  /transition was aborted/i,
 ]
 
 export function isViewTransitionAbortError(reason: unknown): boolean {
   if (!(reason instanceof DOMException)) return false
-  if (reason.name !== 'AbortError' && reason.name !== 'InvalidStateError') {
-    return false
-  }
+  if (reason.name !== 'AbortError') return false
   return VIEW_TRANSITION_ABORT_PATTERNS.some((pattern) =>
     pattern.test(reason.message),
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,10 +27,12 @@ import {
 } from './services/jellyfin/core'
 import { DesktopFallback } from './components/DesktopFallback'
 import { installVitePreloadErrorHandler } from './lib/vite-preload-error'
+import { installViewTransitionAbortHandler } from './lib/view-transition-error'
 
 import './styles.css'
 
 installVitePreloadErrorHandler()
+installViewTransitionAbortHandler()
 
 if (import.meta.env.DEV) {
   const { applyDevMockServerLogin } =
@@ -80,6 +82,11 @@ const router = createRouter({
   defaultPreloadStaleTime: 0,
   defaultViewTransition: {
     types: ({ fromLocation, toLocation, pathChanged, hashChanged }) => {
+      // Skip the very first navigation (no previous location). Plugin mode
+      // redirects away from its entry URL during boot, and a transition
+      // started there is immediately aborted by the follow-up navigation.
+      if (!fromLocation) return false
+
       // Skip transition for hash-only changes (e.g., anchor links)
       if (!pathChanged && hashChanged) return ['instant']
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -68,6 +68,21 @@ const basePath = pluginMode
   : pluginBuild
     ? `/${APP_BASE_ROUTE}`
     : '/'
+
+// The app's navigation animations are defined entirely via
+// `:active-view-transition-type(...)` rules in styles.css. When transition
+// types are unsupported (e.g. Safari/iOS 18.0–18.1 ship startViewTransition
+// without types), TanStack Router bypasses the `types` callback below and
+// starts an untyped transition for every navigation — including the plugin
+// boot redirect, whose aborted transition then rejects unhandled. Without
+// type support none of our animations can apply, so disable view transitions
+// there entirely.
+const supportsViewTransitionTypes =
+  typeof window !== 'undefined' &&
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('selector(:active-view-transition-type(a))')
+
 const router = createRouter({
   routeTree,
   basepath: basePath,
@@ -80,39 +95,41 @@ const router = createRouter({
   // Keep Router preloads immediately stale so Query invalidation/staleTime remain
   // the single source of truth instead of Router's default 30s preload cache.
   defaultPreloadStaleTime: 0,
-  defaultViewTransition: {
-    types: ({ fromLocation, toLocation, pathChanged, hashChanged }) => {
-      // Skip the very first navigation (no previous location). Plugin mode
-      // redirects away from its entry URL during boot, and a transition
-      // started there is immediately aborted by the follow-up navigation.
-      if (!fromLocation) return false
+  defaultViewTransition: supportsViewTransitionTypes
+    ? {
+        types: ({ fromLocation, toLocation, pathChanged, hashChanged }) => {
+          // Skip the very first navigation (no previous location). Plugin mode
+          // redirects away from its entry URL during boot, and a transition
+          // started there is immediately aborted by the follow-up navigation.
+          if (!fromLocation) return false
 
-      // Skip transition for hash-only changes (e.g., anchor links)
-      if (!pathChanged && hashChanged) return ['instant']
+          // Skip transition for hash-only changes (e.g., anchor links)
+          if (!pathChanged && hashChanged) return ['instant']
 
-      // No transition if path didn't change
-      if (!pathChanged) return false
+          // No transition if path didn't change
+          if (!pathChanged) return false
 
-      const from = fromLocation?.pathname ?? ''
-      const to = toLocation.pathname
+          const from = fromLocation.pathname
+          const to = toLocation.pathname
 
-      // Determine navigation direction based on route depth
-      const fromDepth = from.split('/').filter(Boolean).length
-      const toDepth = to.split('/').filter(Boolean).length
+          // Determine navigation direction based on route depth
+          const fromDepth = from.split('/').filter(Boolean).length
+          const toDepth = to.split('/').filter(Boolean).length
 
-      // Special case: navigating to player
-      if (to.includes('/player/')) return ['to-player']
+          // Special case: navigating to player
+          if (to.includes('/player/')) return ['to-player']
 
-      // Forward navigation (drilling down)
-      if (toDepth > fromDepth) return ['forward']
+          // Forward navigation (drilling down)
+          if (toDepth > fromDepth) return ['forward']
 
-      // Back navigation (going up)
-      if (toDepth < fromDepth) return ['back']
+          // Back navigation (going up)
+          if (toDepth < fromDepth) return ['back']
 
-      // Same depth - use forward as default
-      return ['forward']
-    },
-  },
+          // Same depth - use forward as default
+          return ['forward']
+        },
+      }
+    : undefined,
 })
 
 declare module '@tanstack/react-router' {


### PR DESCRIPTION
## Summary

Follow-up to intro-skipper/segment-editor#186 ("iOS support" re-opened after the `requestIdleCallback` fix shipped in plugin v1.0.50). This addresses the two remaining WebKit/iOS defects found while investigating that issue.

### 1. Fullscreen threw a synchronous TypeError on iPhone

`toggleFullscreen` in `src/components/player/Player.tsx` called `container.requestFullscreen()` unguarded. iPhones (unlike iPadOS/desktop Safari) expose **no element fullscreen API at all**, so tapping the fullscreen button threw:

```
TypeError: e.requestFullscreen is not a function. (In 'e.requestFullscreen()', 'e.requestFullscreen' is undefined)
```

— the same unguarded-WebKit-API failure class as the original #186 crash. The `.catch()` on the promise cannot intercept a synchronous throw from calling `undefined`.

Fix: feature-detect `requestFullscreen` and fall back to the WebKit-prefixed native video fullscreen (`video.webkitEnterFullscreen()`), wrapped in try/catch since it throws `InvalidStateError` before playback starts. Desktop/iPad behavior is unchanged.

### 2. Unhandled `AbortError` rejections from aborted view transitions

The router starts a view transition for every path-changing navigation (`defaultViewTransition` in `src/main.tsx`). In plugin mode, boot performs an immediate entry redirect, so the first transition is aborted by the follow-up navigation and its unawaited promises reject as **unhandled errors**:

- WebKit: `AbortError: Old view transition aborted by new view transition.`
- Chromium: `AbortError: Transition was skipped`

Inside the Jellyfin Web host page this is exactly the kind of global error noise that #186 was about. Fix is two-fold:

- Skip the view transition for the very first navigation (no `fromLocation`).
- Install a scoped `unhandledrejection` guard (`src/lib/view-transition-error.ts`, mirroring the existing `installVitePreloadErrorHandler` pattern) that `preventDefault()`s only `DOMException`s whose name/message match view-transition aborts. Unrelated `AbortError`s (e.g. cancelled fetches) are not swallowed — covered by tests.

## Verification (real WebKit via Playwright, iPhone UA/viewport, mock Jellyfin server)

| Scenario | Before | After |
|---|---|---|
| Player → tap fullscreen with `Element.requestFullscreen` absent (iPhone condition) | `TypeError … requestFullscreen is not a function` page error | 0 page errors, tap falls back cleanly |
| Plugin-embedded boot (`configPage.html`-style module script + `window.ApiClient` shim) → browse library | `AbortError: Old view transition aborted by new view transition` unhandled rejection | 0 page errors, browse flow intact |
| Standalone full flow (connect → login → collection → series → player editor) | clean | still clean |

Also: `tsc --noEmit` passes; new unit tests (8) for the abort-error matcher/handler pass; full vitest suite passes (`oxlint` currently panics on this VM with an internal allocator error on the untouched tree too — pre-existing environment issue, CI should be authoritative).

## Notes for reviewers

- The `types` callback change only affects the first navigation after boot (`!fromLocation`); forward/back transition classification for user navigation is untouched.
- `use-fullscreen-player-ui.ts` still listens to standard `fullscreenchange` only. On iPhone the native video player manages its own UI in `webkitEnterFullscreen` mode, so no state wiring is needed there.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/61acd7cd-23a4-4579-8b96-3e4893bb61b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-093" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/61acd7cd-23a4-4579-8b96-3e4893bb61b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-093&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-093"><img alt="INTRO-093" src="https://capy.ai/api/badge/thread.svg?label=INTRO-093"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Guard player fullscreen behavior on iPhone Safari and suppress noise from aborted view transition promise rejections.

Bug Fixes:
- Prevent player fullscreen toggle from throwing when Element.requestFullscreen is unavailable, falling back to native video fullscreen where supported.
- Avoid unhandled promise rejections from aborted view transitions by skipping the initial redirect transition and filtering out known view-transition abort errors from global error handling.

Tests:
- Add unit tests covering detection and handling of view-transition abort errors and installation/removal of the unhandledrejection listener.