### PR TITLE
Switch to Geist/Geist Mono and fix numeric typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@jellyfin/sdk": "^0.13.0",
     "@material/material-color-utilities": "^0.4.0",
     "@tanstack/react-form": "^1.33.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,10 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@fontsource-variable/dm-sans':
+      '@fontsource-variable/geist':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource-variable/geist-mono':
         specifier: ^5.2.8
         version: 5.2.8
       '@jellyfin/sdk':
@@ -862,8 +865,11 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@fontsource-variable/dm-sans@5.2.8':
-    resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
+  '@fontsource-variable/geist-mono@5.2.8':
+    resolution: {integrity: sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==}
+
+  '@fontsource-variable/geist@5.2.9':
+    resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -6198,7 +6204,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@fontsource-variable/dm-sans@5.2.8': {}
+  '@fontsource-variable/geist-mono@5.2.8': {}
+
+  '@fontsource-variable/geist@5.2.9': {}
 
   '@hono/node-server@1.19.14(hono@4.12.30)':
     dependencies:

--- a/src/components/player/PlayerScrubber.tsx
+++ b/src/components/player/PlayerScrubber.tsx
@@ -179,7 +179,7 @@ function HoverTimePreview({
       style={hoverIndicatorStyle}
     >
       {trickplayPosition && <TrickplayPreview position={trickplayPosition} />}
-      <div className="bg-popover text-popover-foreground text-xs px-2 py-1 rounded shadow-lg whitespace-nowrap">
+      <div className="bg-popover text-popover-foreground text-xs px-2 py-1 rounded shadow-lg whitespace-nowrap tabular-nums">
         {formatTime(hoverTime)}
       </div>
     </div>

--- a/src/components/player/PlayerSettingsMenu.tsx
+++ b/src/components/player/PlayerSettingsMenu.tsx
@@ -202,7 +202,7 @@ export function PlayerSettingsMenu({
                   )}
                   className="flex-1 h-2 appearance-none bg-muted rounded-full cursor-pointer accent-primary"
                 />
-                <span className="text-sm font-mono min-w-[6ch] text-right">
+                <span className="text-sm tabular-nums min-w-[6ch] text-right">
                   {subtitleOffset > 0 ? '+' : ''}
                   {subtitleOffset.toFixed(1)}s
                 </span>

--- a/src/components/segment/SegmentEditDialog.tsx
+++ b/src/components/segment/SegmentEditDialog.tsx
@@ -258,7 +258,7 @@ function SegmentEditDialogContent({
                       onBlur={() => handleTimeFieldBlur(field)}
                       className="font-mono flex-1"
                     />
-                    <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    <span className="text-sm text-muted-foreground whitespace-nowrap tabular-nums">
                       {formatTime(draftRange.startSeconds)}
                     </span>
                   </div>
@@ -290,7 +290,7 @@ function SegmentEditDialogContent({
                       onBlur={() => handleTimeFieldBlur(field)}
                       className="font-mono flex-1"
                     />
-                    <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    <span className="text-sm text-muted-foreground whitespace-nowrap tabular-nums">
                       {formatTime(draftRange.endSeconds)}
                     </span>
                   </div>
@@ -301,10 +301,10 @@ function SegmentEditDialogContent({
             <div className="grid grid-cols-1 sm:grid-cols-4 items-start sm:items-center gap-2 sm:gap-4">
               <Label className="sm:text-right">{t('segment.duration')}</Label>
               <div className="sm:col-span-3">
-                <span className="text-sm font-mono">
+                <span className="text-sm tabular-nums">
                   {formatTime(duration)}
                 </span>
-                <span className="text-sm text-muted-foreground ml-2">
+                <span className="text-sm text-muted-foreground ml-2 tabular-nums">
                   ({duration.toFixed(3)}s)
                 </span>
               </div>

--- a/src/components/views/AlbumView.tsx
+++ b/src/components/views/AlbumView.tsx
@@ -45,7 +45,10 @@ const TrackRow = function TrackRowComponent({
       )}
       aria-label={`Play track ${trackNumber}: ${track.Name || `Track ${trackNumber}`}, duration ${duration}`}
     >
-      <div className="w-8 text-center text-muted-foreground" aria-hidden="true">
+      <div
+        className="w-8 text-center text-muted-foreground tabular-nums"
+        aria-hidden="true"
+      >
         <span className="group-hover:hidden">{trackNumber}</span>
         <Play className="size-4 hidden group-hover:inline" />
       </div>
@@ -57,7 +60,7 @@ const TrackRow = function TrackRowComponent({
       </div>
 
       <div
-        className="text-sm text-muted-foreground"
+        className="text-sm text-muted-foreground tabular-nums"
         aria-label={`Duration: ${duration}`}
       >
         {duration}

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -186,7 +186,7 @@ const EpisodeCard = function EpisodeCardComponent({
         <p className="font-semibold truncate leading-tight text-base md:text-lg text-foreground">
           {episode.Name || episodeLabel}
         </p>
-        <p className="text-sm md:text-base truncate mt-0.5 md:mt-1 text-muted-foreground">
+        <p className="text-sm md:text-base truncate mt-0.5 md:mt-1 text-muted-foreground tabular-nums">
           {episode.Name ? episodeLabel : t('series.episode')}
           {runtime && ` · ${runtime} min`}
         </p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,8 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
-@import '@fontsource-variable/dm-sans';
+@import '@fontsource-variable/geist';
+@import '@fontsource-variable/geist-mono';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -207,9 +208,9 @@
 }
 
 @theme inline {
-  --font-sans: 'DM Sans Variable', ui-sans-serif, system-ui, sans-serif;
+  --font-sans: 'Geist Variable', ui-sans-serif, system-ui, sans-serif;
   --font-serif: serif;
-  --font-mono: 'JetBrains Mono Variable', ui-monospace, monospace;
+  --font-mono: 'Geist Mono Variable', ui-monospace, monospace;
   /* Spacing tokens */
   --spacing-button-min: var(--spacing-button-min);
   --spacing-dropdown-min: var(--spacing-dropdown-min);
@@ -713,12 +714,6 @@ textarea:focus,
 select:focus {
   border-color: var(--ring);
   box-shadow: 0 0 0 3px oklch(from var(--ring) l c h / 12%);
-}
-
-/* Time input - monospace with better alignment */
-input[type='number'].time-input {
-  font-variant-numeric: tabular-nums;
-  text-align: right;
 }
 
 /* Dialog backdrop blur enhancement */


### PR DESCRIPTION
DM Sans Variable ships no `tnum` OpenType feature, so every `tabular-nums` utility in the app (scrubber timecodes, episode switcher, command palette) was a silent no-op and live-updating timestamps jittered as digit widths changed. `--font-mono` also pointed at JetBrains Mono, which was never installed, so mono surfaces fell back to whatever `ui-monospace` the OS provides.

This swaps the font stack to Geist / Geist Mono (both fontsource variable packages, same pipeline as before) and applies a consistent numeric-typography policy:

- `--font-sans` → 'Geist Variable', `--font-mono` → 'Geist Mono Variable'. Geist ships `tnum`, so existing `tabular-nums` usage now actually works.
- Editable values and technical identifiers stay mono: segment timestamp inputs, codec/container badges, `kbd` hints, the desktop-fallback URL.
- Read-only numeric readouts use proportional sans + `tabular-nums`: converted the segment dialog's duration line and the subtitle-offset readout from mono, and added missing `tabular-nums` to the scrubber hover-time preview and the segment dialog's live time previews.
- Removed the unused `input[type='number'].time-input` rule (no matching markup).

Verified in-browser: both families load (`document.fonts.check` true) and the UI renders in Geist; build, format check, and all 594 tests pass.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/cdf37071-2fd1-476a-a535-529a16f16afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-100" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/cdf37071-2fd1-476a-a535-529a16f16afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-100&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-100"><img alt="INTRO-100" src="https://capy.ai/api/badge/thread.svg?label=INTRO-100"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Switch the UI font stack to Geist/Geist Mono and standardize numeric typography for time-related readouts.

New Features:
- Adopt Geist Variable as the primary sans-serif font and Geist Mono Variable as the monospace font across the app.

Enhancements:
- Apply tabular numeric styling to time and duration readouts to prevent jitter and improve alignment in scrubbers, segment dialogs, and subtitle offset displays.
- Remove an unused time-input CSS rule that no longer corresponds to any markup.
- Update font dependencies to use Geist and Geist Mono variable packages in the build configuration.