### PR TITLE
fix(player): clear HLS error overlay on real recovery and make Retry reliable

### DIFF
--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { act, render, waitFor } from '@testing-library/react'
-import { useReducer } from 'react'
+import { useEffect, useReducer } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BaseItemDto } from '@/types/jellyfin'
@@ -18,6 +18,13 @@ import type {
   VideoPlayerErrorType,
 } from '@/hooks/use-video-player'
 import type { HlsPlayerError } from '@/hooks/use-hls-player'
+import { useVideoPlayer } from '@/hooks/use-video-player'
+import {
+  initialPlayerState,
+  playerReducer,
+} from '@/components/player/player-reducer'
+import type { PlayerState } from '@/components/player/player-reducer'
+import { getPlaybackConfig } from '@/services/video/api'
 
 type Listener = (event: string, data: unknown) => void
 
@@ -113,14 +120,6 @@ vi.mock('@/services/video/transcode-session', () => ({
   stopActiveEncodingKeepalive: vi.fn(),
 }))
 
-import { useVideoPlayer } from '@/hooks/use-video-player'
-import {
-  initialPlayerState,
-  playerReducer,
-} from '@/components/player/player-reducer'
-import type { PlayerState } from '@/components/player/player-reducer'
-import { getPlaybackConfig } from '@/services/video/api'
-
 function mapVideoErrorType(type: VideoPlayerErrorType): HlsPlayerError['type'] {
   switch (type) {
     case 'media_error':
@@ -168,11 +167,18 @@ function Harness({ item }: { item: BaseItemDto }) {
     },
     t: (key: string) => key,
   })
+  const { retry, videoRef } = player
 
-  observed.state = state
-  observed.retry = player.retry
+  useEffect(() => {
+    observed.state = state
+    observed.retry = retry
+  })
 
-  return <video ref={player.videoRef} />
+  return (
+    <video ref={videoRef} muted>
+      <track kind="captions" />
+    </video>
+  )
 }
 
 /** Mirrors PlayerSurface's overlay conditions. */

--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -327,4 +327,25 @@ describe('HLS error recovery overlay lifecycle', () => {
     expect(hls.swapAudioCodecCalls).toBe(1)
     expect(hls.recoverCalls).toBe(2)
   })
+
+  it('does not swap the audio codec for a new media error after a successful recovery', async () => {
+    const { hls } = await renderPlayingHarness()
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(hls.recoverCalls).toBe(1)
+
+    // Playback genuinely recovers: the swap window must reset so the next
+    // independent media error does not needlessly swap a working audio track.
+    act(() => {
+      hls.emit('hlsFragBuffered')
+    })
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(hls.swapAudioCodecCalls).toBe(0)
+    expect(hls.recoverCalls).toBe(2)
+  })
 })

--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the HLS error-recovery overlay lifecycle
+ * (intro-skipper/segment-editor-plugin#7: error overlay never disappeared
+ * after playback recovered).
+ *
+ * Wires useVideoPlayer (with the real useHlsPlayer) to the real playerReducer
+ * exactly like Player.tsx does, and drives hls.js events through a fake.
+ */
+
+import { act, render, waitFor } from '@testing-library/react'
+import { useReducer } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BaseItemDto } from '@/types/jellyfin'
+import type {
+  VideoPlayerError,
+  VideoPlayerErrorType,
+} from '@/hooks/use-video-player'
+import type { HlsPlayerError } from '@/hooks/use-hls-player'
+
+type Listener = (event: string, data: unknown) => void
+
+interface FakeHlsInstance {
+  listeners: Map<string, Set<Listener>>
+  destroyed: boolean
+  loadedUrls: Array<string>
+  recoverCalls: number
+  swapAudioCodecCalls: number
+  config: Record<string, unknown>
+  emit: (event: string, data?: unknown) => void
+}
+
+const hlsState = vi.hoisted(() => ({
+  instances: [] as Array<FakeHlsInstance>,
+}))
+
+vi.mock('hls.js', () => {
+  class FakeHls implements FakeHlsInstance {
+    static Events = {
+      ERROR: 'hlsError',
+      MANIFEST_PARSED: 'hlsManifestParsed',
+      FRAG_BUFFERED: 'hlsFragBuffered',
+    }
+    static ErrorTypes = {
+      NETWORK_ERROR: 'networkError',
+      MEDIA_ERROR: 'mediaError',
+      OTHER_ERROR: 'otherError',
+    }
+    static isSupported = () => true
+
+    listeners = new Map<string, Set<Listener>>()
+    destroyed = false
+    loadedUrls: Array<string> = []
+    recoverCalls = 0
+    swapAudioCodecCalls = 0
+    config: Record<string, unknown>
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config
+      hlsState.instances.push(this)
+    }
+    attachMedia() {}
+    loadSource(url: string) {
+      this.loadedUrls.push(url)
+    }
+    on(event: string, listener: Listener) {
+      if (!this.listeners.has(event)) this.listeners.set(event, new Set())
+      this.listeners.get(event)!.add(listener)
+    }
+    off(event: string, listener: Listener) {
+      this.listeners.get(event)?.delete(listener)
+    }
+    destroy() {
+      this.destroyed = true
+      this.listeners.clear()
+    }
+    recoverMediaError() {
+      this.recoverCalls++
+    }
+    swapAudioCodec() {
+      this.swapAudioCodecCalls++
+    }
+    startLoad() {}
+    emit(event: string, data: unknown = {}) {
+      for (const listener of [...(this.listeners.get(event) ?? [])]) {
+        listener(event, data)
+      }
+    }
+  }
+  return { default: FakeHls }
+})
+
+vi.mock('@/services/video/api', () => ({
+  getPlaybackConfig: vi.fn(),
+  getPlaybackMediaSourceId: (item: BaseItemDto) =>
+    item.MediaSources?.[0]?.Id ?? item.Id?.replace(/-/g, ''),
+}))
+
+vi.mock('@/services/video/playback-session', () => ({
+  reportPlaybackProgress: vi.fn().mockResolvedValue(undefined),
+  startPlaybackStatus: vi.fn().mockResolvedValue(undefined),
+  stopPlaybackStatus: vi.fn().mockResolvedValue(undefined),
+  stopPlaybackStatusKeepalive: vi.fn(),
+}))
+
+vi.mock('@/services/video/session', () => ({
+  createPlaySessionId: vi.fn(() => 'session-1'),
+}))
+
+vi.mock('@/services/video/transcode-session', () => ({
+  stopActiveEncoding: vi.fn().mockResolvedValue(undefined),
+  stopActiveEncodingKeepalive: vi.fn(),
+}))
+
+import { useVideoPlayer } from '@/hooks/use-video-player'
+import {
+  initialPlayerState,
+  playerReducer,
+} from '@/components/player/player-reducer'
+import type { PlayerState } from '@/components/player/player-reducer'
+import { getPlaybackConfig } from '@/services/video/api'
+
+function mapVideoErrorType(type: VideoPlayerErrorType): HlsPlayerError['type'] {
+  switch (type) {
+    case 'media_error':
+      return 'media'
+    case 'network_error':
+      return 'network'
+    default:
+      return 'unknown'
+  }
+}
+
+const observed: { state: PlayerState; retry: () => void } = {
+  state: initialPlayerState,
+  retry: () => {},
+}
+
+/** Replicates the error/recovery wiring between Player.tsx and useVideoPlayer. */
+function Harness({ item }: { item: BaseItemDto }) {
+  const [state, dispatch] = useReducer(playerReducer, initialPlayerState)
+
+  const handleVideoError = (error: VideoPlayerError | null) => {
+    if (error) {
+      const hlsError: HlsPlayerError = {
+        type: mapVideoErrorType(error.type),
+        message: error.message,
+        recoverable: error.recoverable,
+      }
+      dispatch({ type: 'ERROR_STATE', error: hlsError, isRecovering: false })
+    } else {
+      dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
+    }
+  }
+
+  const player = useVideoPlayer({
+    item,
+    onError: handleVideoError,
+    onStrategyChange: () => {
+      dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
+    },
+    onRecoveryStart: () => {
+      dispatch({ type: 'RECOVERY_START' })
+    },
+    onRecoveryEnd: () => {
+      dispatch({ type: 'RECOVERY_END' })
+    },
+    t: (key: string) => key,
+  })
+
+  observed.state = state
+  observed.retry = player.retry
+
+  return <video ref={player.videoRef} />
+}
+
+/** Mirrors PlayerSurface's overlay conditions. */
+function errorOverlayVisible() {
+  return Boolean(observed.state.playerError && !observed.state.isRecovering)
+}
+
+const HLS_URL = 'https://jellyfin.example/Videos/item-1/master.m3u8'
+
+async function renderPlayingHarness() {
+  vi.mocked(getPlaybackConfig).mockResolvedValue({
+    strategy: 'hls',
+    url: HLS_URL,
+  })
+  const utils = render(
+    <Harness
+      item={{
+        Id: 'item-1',
+        Name: 'MP2 Movie',
+        Type: 'Movie',
+        MediaSources: [{ Id: 'media-source-1' }],
+      }}
+    />,
+  )
+  await waitFor(() => {
+    expect(hlsState.instances.at(-1)?.loadedUrls).toContain(HLS_URL)
+  })
+  const hls = hlsState.instances.at(-1)!
+  act(() => {
+    hls.emit('hlsManifestParsed')
+  })
+  return { utils, hls }
+}
+
+const fatalMediaError = {
+  type: 'mediaError',
+  details: 'bufferAppendError',
+  fatal: true,
+}
+const fatalOtherError = { type: 'otherError', details: 'muxError', fatal: true }
+
+describe('HLS error recovery overlay lifecycle', () => {
+  beforeEach(() => {
+    hlsState.instances.length = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('clears the error state as soon as a fragment buffers after recovery', async () => {
+    const { hls } = await renderPlayingHarness()
+    vi.useFakeTimers()
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(observed.state.playerError).not.toBeNull()
+    expect(observed.state.isRecovering).toBe(true)
+    expect(hls.recoverCalls).toBe(1)
+
+    // Playback resumes: a fragment appends successfully well before the
+    // fallback recovery timer would have fired.
+    act(() => {
+      hls.emit('hlsFragBuffered')
+    })
+
+    expect(observed.state.playerError).toBeNull()
+    expect(observed.state.isRecovering).toBe(false)
+    expect(errorOverlayVisible()).toBe(false)
+  })
+
+  it('falls back to the recovery timer when no fragment buffers', async () => {
+    const { hls } = await renderPlayingHarness()
+    vi.useFakeTimers()
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(observed.state.isRecovering).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(2100)
+    })
+
+    expect(observed.state.playerError).toBeNull()
+    expect(observed.state.isRecovering).toBe(false)
+  })
+
+  it('keeps unknown fatal errors recoverable and rebuilds the player on retry', async () => {
+    const { hls, utils } = await renderPlayingHarness()
+
+    act(() => {
+      hls.emit('hlsError', fatalOtherError)
+    })
+    expect(errorOverlayVisible()).toBe(true)
+    expect(observed.state.playerError?.recoverable).toBe(true)
+
+    const video = utils.container.querySelector('video')!
+    Object.defineProperty(video, 'currentTime', {
+      configurable: true,
+      value: 42,
+    })
+
+    const instancesBefore = hlsState.instances.length
+    act(() => {
+      observed.retry()
+    })
+
+    // The overlay clears immediately on retry...
+    expect(observed.state.playerError).toBeNull()
+    expect(errorOverlayVisible()).toBe(false)
+
+    // ...and a fresh Hls instance reloads the source from the same position.
+    await waitFor(() => {
+      expect(hlsState.instances.length).toBe(instancesBefore + 1)
+      expect(hlsState.instances.at(-1)?.loadedUrls).toContain(HLS_URL)
+    })
+    expect(hls.destroyed).toBe(true)
+    expect(hlsState.instances.at(-1)?.config.startPosition).toBe(42)
+  })
+
+  it('clears a stuck unknown error once fragments buffer again', async () => {
+    const { hls } = await renderPlayingHarness()
+
+    act(() => {
+      hls.emit('hlsError', fatalOtherError)
+    })
+    expect(errorOverlayVisible()).toBe(true)
+
+    act(() => {
+      hls.emit('hlsFragBuffered')
+    })
+
+    expect(errorOverlayVisible()).toBe(false)
+    expect(observed.state.playerError).toBeNull()
+  })
+
+  it('swaps the audio codec when media errors repeat within the swap window', async () => {
+    const { hls } = await renderPlayingHarness()
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(hls.swapAudioCodecCalls).toBe(0)
+    expect(hls.recoverCalls).toBe(1)
+
+    act(() => {
+      hls.emit('hlsError', fatalMediaError)
+    })
+    expect(hls.swapAudioCodecCalls).toBe(1)
+    expect(hls.recoverCalls).toBe(2)
+  })
+})

--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -13,23 +13,21 @@ import { useEffect, useReducer } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BaseItemDto } from '@/types/jellyfin'
-import type {
-  VideoPlayerError,
-  VideoPlayerErrorType,
-} from '@/hooks/use-video-player'
+import type { VideoPlayerError } from '@/hooks/use-video-player'
 import type { HlsPlayerError } from '@/hooks/use-hls-player'
 import { useVideoPlayer } from '@/hooks/use-video-player'
 import {
   initialPlayerState,
+  mapVideoErrorType,
   playerReducer,
 } from '@/components/player/player-reducer'
 import type { PlayerState } from '@/components/player/player-reducer'
 import { getPlaybackConfig } from '@/services/video/api'
+import type * as VideoApiModule from '@/services/video/api'
 
 type Listener = (event: string, data: unknown) => void
 
 interface FakeHlsInstance {
-  listeners: Map<string, Set<Listener>>
   destroyed: boolean
   loadedUrls: Array<string>
   recoverCalls: number
@@ -52,7 +50,6 @@ vi.mock('hls.js', () => {
     static ErrorTypes = {
       NETWORK_ERROR: 'networkError',
       MEDIA_ERROR: 'mediaError',
-      OTHER_ERROR: 'otherError',
     }
     static isSupported = () => true
 
@@ -98,10 +95,11 @@ vi.mock('hls.js', () => {
   return { default: FakeHls }
 })
 
-vi.mock('@/services/video/api', () => ({
+vi.mock('@/services/video/api', async (importOriginal) => ({
+  // Keep the real getPlaybackMediaSourceId so the test cannot drift from the
+  // production fallback logic.
+  ...(await importOriginal<typeof VideoApiModule>()),
   getPlaybackConfig: vi.fn(),
-  getPlaybackMediaSourceId: (item: BaseItemDto) =>
-    item.MediaSources?.[0]?.Id ?? item.Id?.replace(/-/g, ''),
 }))
 
 vi.mock('@/services/video/playback-session', () => ({
@@ -119,17 +117,6 @@ vi.mock('@/services/video/transcode-session', () => ({
   stopActiveEncoding: vi.fn().mockResolvedValue(undefined),
   stopActiveEncodingKeepalive: vi.fn(),
 }))
-
-function mapVideoErrorType(type: VideoPlayerErrorType): HlsPlayerError['type'] {
-  switch (type) {
-    case 'media_error':
-      return 'media'
-    case 'network_error':
-      return 'network'
-    default:
-      return 'unknown'
-  }
-}
 
 const observed: { state: PlayerState; retry: () => void } = {
   state: initialPlayerState,
@@ -186,6 +173,12 @@ function errorOverlayVisible() {
   return Boolean(observed.state.playerError && !observed.state.isRecovering)
 }
 
+function emitHlsEvent(hls: FakeHlsInstance, event: string, data?: unknown) {
+  act(() => {
+    hls.emit(event, data)
+  })
+}
+
 const HLS_URL = 'https://jellyfin.example/Videos/item-1/master.m3u8'
 
 async function renderPlayingHarness() {
@@ -207,9 +200,7 @@ async function renderPlayingHarness() {
     expect(hlsState.instances.at(-1)?.loadedUrls).toContain(HLS_URL)
   })
   const hls = hlsState.instances.at(-1)!
-  act(() => {
-    hls.emit('hlsManifestParsed')
-  })
+  emitHlsEvent(hls, 'hlsManifestParsed')
   return { utils, hls }
 }
 
@@ -232,20 +223,15 @@ describe('HLS error recovery overlay lifecycle', () => {
 
   it('clears the error state as soon as a fragment buffers after recovery', async () => {
     const { hls } = await renderPlayingHarness()
-    vi.useFakeTimers()
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(observed.state.playerError).not.toBeNull()
     expect(observed.state.isRecovering).toBe(true)
     expect(hls.recoverCalls).toBe(1)
 
     // Playback resumes: a fragment appends successfully well before the
     // fallback recovery timer would have fired.
-    act(() => {
-      hls.emit('hlsFragBuffered')
-    })
+    emitHlsEvent(hls, 'hlsFragBuffered')
 
     expect(observed.state.playerError).toBeNull()
     expect(observed.state.isRecovering).toBe(false)
@@ -256,9 +242,7 @@ describe('HLS error recovery overlay lifecycle', () => {
     const { hls } = await renderPlayingHarness()
     vi.useFakeTimers()
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(observed.state.isRecovering).toBe(true)
 
     act(() => {
@@ -272,9 +256,7 @@ describe('HLS error recovery overlay lifecycle', () => {
   it('keeps unknown fatal errors recoverable and rebuilds the player on retry', async () => {
     const { hls, utils } = await renderPlayingHarness()
 
-    act(() => {
-      hls.emit('hlsError', fatalOtherError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalOtherError)
     expect(errorOverlayVisible()).toBe(true)
     expect(observed.state.playerError?.recoverable).toBe(true)
 
@@ -305,14 +287,10 @@ describe('HLS error recovery overlay lifecycle', () => {
   it('clears a stuck unknown error once fragments buffer again', async () => {
     const { hls } = await renderPlayingHarness()
 
-    act(() => {
-      hls.emit('hlsError', fatalOtherError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalOtherError)
     expect(errorOverlayVisible()).toBe(true)
 
-    act(() => {
-      hls.emit('hlsFragBuffered')
-    })
+    emitHlsEvent(hls, 'hlsFragBuffered')
 
     expect(errorOverlayVisible()).toBe(false)
     expect(observed.state.playerError).toBeNull()
@@ -321,15 +299,11 @@ describe('HLS error recovery overlay lifecycle', () => {
   it('swaps the audio codec when media errors repeat within the swap window', async () => {
     const { hls } = await renderPlayingHarness()
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(hls.swapAudioCodecCalls).toBe(0)
     expect(hls.recoverCalls).toBe(1)
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(hls.swapAudioCodecCalls).toBe(1)
     expect(hls.recoverCalls).toBe(2)
   })
@@ -337,20 +311,14 @@ describe('HLS error recovery overlay lifecycle', () => {
   it('does not swap the audio codec for a new media error after a successful recovery', async () => {
     const { hls } = await renderPlayingHarness()
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(hls.recoverCalls).toBe(1)
 
     // Playback genuinely recovers: the swap window must reset so the next
     // independent media error does not needlessly swap a working audio track.
-    act(() => {
-      hls.emit('hlsFragBuffered')
-    })
+    emitHlsEvent(hls, 'hlsFragBuffered')
 
-    act(() => {
-      hls.emit('hlsError', fatalMediaError)
-    })
+    emitHlsEvent(hls, 'hlsError', fatalMediaError)
     expect(hls.swapAudioCodecCalls).toBe(0)
     expect(hls.recoverCalls).toBe(2)
   })

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -13,7 +13,11 @@ import { useShallow } from 'zustand/react/shallow'
 import { PlayerScrubber } from './PlayerScrubber'
 import { PlayerSurface } from './PlayerSurface'
 import type { PlayerControlsProps } from './PlayerControls'
-import { initialPlayerState, playerReducer } from './player-reducer'
+import {
+  initialPlayerState,
+  mapVideoErrorType,
+  playerReducer,
+} from './player-reducer'
 import {
   buildSegmentTimeIndex,
   findActiveSegmentRange,
@@ -27,10 +31,7 @@ import type {
   MediaSegmentDto,
   MediaSegmentType,
 } from '@/types/jellyfin'
-import type {
-  VideoPlayerError,
-  VideoPlayerErrorType,
-} from '@/hooks/use-video-player'
+import type { VideoPlayerError } from '@/hooks/use-video-player'
 import type { HlsPlayerError } from '@/hooks/use-hls-player'
 import type { CreateSegmentData, TimestampUpdate } from '@/types/segment'
 import type { PlaybackStrategy } from '@/services/video/api'
@@ -167,17 +168,6 @@ function findItemPreferredAudioStreamIndex(
 // re-render the whole player tree for a value the render ignores.
 const readPreferredAudioLanguage = () =>
   useAppStore.getState().trackPreferences.preferredAudioLanguage
-
-function mapVideoErrorType(type: VideoPlayerErrorType): HlsPlayerError['type'] {
-  switch (type) {
-    case 'media_error':
-      return 'media'
-    case 'network_error':
-      return 'network'
-    default:
-      return 'unknown'
-  }
-}
 
 interface PlayerProps {
   item: BaseItemDto

--- a/src/components/player/player-reducer.ts
+++ b/src/components/player/player-reducer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { HlsPlayerError } from '@/hooks/use-hls-player'
+import type { VideoPlayerErrorType } from '@/hooks/use-video-player'
 import { PLAYER_CONFIG } from '@/lib/constants'
 
 const {
@@ -48,6 +49,20 @@ export type PlayerAction =
   | { type: 'SUBTITLE_OFFSET_CHANGE'; offset: number }
   | { type: 'CYCLE_SPEED'; direction: 1 | -1 }
   | { type: 'SET_SPEED'; speedIndex: number }
+
+/** Maps useVideoPlayer error types onto the reducer's HlsPlayerError taxonomy. */
+export function mapVideoErrorType(
+  type: VideoPlayerErrorType,
+): HlsPlayerError['type'] {
+  switch (type) {
+    case 'media_error':
+      return 'media'
+    case 'network_error':
+      return 'network'
+    default:
+      return 'unknown'
+  }
+}
 
 export const initialPlayerState: PlayerState = {
   isPlaying: false,

--- a/src/hooks/use-hls-player.ts
+++ b/src/hooks/use-hls-player.ts
@@ -3,14 +3,7 @@ import Hls from 'hls.js'
 import type { ErrorData } from 'hls.js'
 import { PLAYER_CONFIG } from '@/lib/constants'
 
-const { RECOVERY_TIMEOUT_MS } = PLAYER_CONFIG
-
-/**
- * When a second fatal media error arrives within this window after a
- * recoverMediaError() attempt, hls.js documentation prescribes calling
- * swapAudioCodec() before retrying recovery.
- */
-const MEDIA_ERROR_SWAP_WINDOW_MS = 3000
+const { RECOVERY_TIMEOUT_MS, MEDIA_ERROR_SWAP_WINDOW_MS } = PLAYER_CONFIG
 
 export interface HlsPlayerError {
   type: 'network' | 'media' | 'unknown'
@@ -78,10 +71,11 @@ export function useHlsPlayer({
   const lastMediaRecoveryAtRef = useRef(Number.NEGATIVE_INFINITY)
   /** Bumped by retry() to tear down and rebuild the Hls instance */
   const [reloadToken, setReloadToken] = useState(0)
-  /** Position to resume from when retry() rebuilds the instance */
-  const retryStartPositionRef = useRef<number | null>(null)
+  /** Position to resume from when retry() rebuilds the instance (-1 = hls.js default) */
+  const retryStartPositionRef = useRef(-1)
 
   const reportError = useEffectEvent((error: HlsPlayerError | null) => {
+    hasPendingErrorRef.current = error !== null
     onError(error)
   })
 
@@ -116,7 +110,6 @@ export function useHlsPlayer({
     }
 
     isActiveRef.current = true
-    hasPendingErrorRef.current = false
     lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
 
     reportError(null)
@@ -127,13 +120,9 @@ export function useHlsPlayer({
     }
 
     if (Hls.isSupported()) {
-      const retryStartPosition = retryStartPositionRef.current
-      retryStartPositionRef.current = null
-      const hls = new Hls(
-        retryStartPosition !== null && retryStartPosition > 0
-          ? { ...HLS_CONFIG, startPosition: retryStartPosition }
-          : HLS_CONFIG,
-      )
+      const startPosition = retryStartPositionRef.current
+      retryStartPositionRef.current = -1
+      const hls = new Hls({ ...HLS_CONFIG, startPosition })
       hls.attachMedia(video)
 
       const handleRecovery = (
@@ -143,7 +132,6 @@ export function useHlsPlayer({
       ) => {
         if (!isActiveRef.current) return
 
-        hasPendingErrorRef.current = true
         reportError(createLocalizedError(type, msgKey, true))
         reportRecoveryStart()
         recoveryFn()
@@ -187,11 +175,17 @@ export function useHlsPlayer({
             // Recoverable via the Retry button, which rebuilds the Hls
             // instance. Marking it non-recoverable would strand the user on
             // a permanent error overlay with no way out.
-            hasPendingErrorRef.current = true
             reportError(
               createLocalizedError('unknown', 'player.error.unknown', true),
             )
         }
+      }
+
+      const markPlaybackHealthy = () => {
+        lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
+        reportError(null)
+        clearRecoveryTimer(recoveryTimerRef)
+        reportRecoveryEnd()
       }
 
       const handleFragBuffered = () => {
@@ -199,20 +193,12 @@ export function useHlsPlayer({
         // A fragment appended successfully after an error: playback has
         // genuinely recovered, so clear the error overlay now instead of
         // waiting for the blind recovery timer.
-        hasPendingErrorRef.current = false
-        lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
-        reportError(null)
-        clearRecoveryTimer(recoveryTimerRef)
-        reportRecoveryEnd()
+        markPlaybackHealthy()
       }
 
       const handleManifestParsed = () => {
         if (!isActiveRef.current) return
-        hasPendingErrorRef.current = false
-        lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
-        reportError(null)
-        clearRecoveryTimer(recoveryTimerRef)
-        reportRecoveryEnd()
+        markPlaybackHealthy()
       }
 
       hls.on(Hls.Events.ERROR, handleError)
@@ -252,11 +238,11 @@ export function useHlsPlayer({
   }, [videoUrl, reloadToken])
 
   const retry = () => {
-    onError(null)
     // Rebuild the Hls instance from scratch: after a fatal error the current
     // instance (and its MediaSource) may be beyond repair, so reloading the
     // source on it is not reliable. Resume from the current position.
-    retryStartPositionRef.current = videoRef.current?.currentTime ?? null
+    const currentTime = videoRef.current?.currentTime ?? 0
+    retryStartPositionRef.current = currentTime > 0 ? currentTime : -1
     setReloadToken((token) => token + 1)
   }
 

--- a/src/hooks/use-hls-player.ts
+++ b/src/hooks/use-hls-player.ts
@@ -200,6 +200,7 @@ export function useHlsPlayer({
         // genuinely recovered, so clear the error overlay now instead of
         // waiting for the blind recovery timer.
         hasPendingErrorRef.current = false
+        lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
         reportError(null)
         clearRecoveryTimer(recoveryTimerRef)
         reportRecoveryEnd()
@@ -208,6 +209,7 @@ export function useHlsPlayer({
       const handleManifestParsed = () => {
         if (!isActiveRef.current) return
         hasPendingErrorRef.current = false
+        lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
         reportError(null)
         clearRecoveryTimer(recoveryTimerRef)
         reportRecoveryEnd()

--- a/src/hooks/use-hls-player.ts
+++ b/src/hooks/use-hls-player.ts
@@ -1,9 +1,16 @@
-import { useEffect, useEffectEvent, useRef } from 'react'
+import { useEffect, useEffectEvent, useRef, useState } from 'react'
 import Hls from 'hls.js'
 import type { ErrorData } from 'hls.js'
 import { PLAYER_CONFIG } from '@/lib/constants'
 
 const { RECOVERY_TIMEOUT_MS } = PLAYER_CONFIG
+
+/**
+ * When a second fatal media error arrives within this window after a
+ * recoverMediaError() attempt, hls.js documentation prescribes calling
+ * swapAudioCodec() before retrying recovery.
+ */
+const MEDIA_ERROR_SWAP_WINDOW_MS = 3000
 
 export interface HlsPlayerError {
   type: 'network' | 'media' | 'unknown'
@@ -66,6 +73,13 @@ export function useHlsPlayer({
   const hlsRef = useRef<Hls | null>(null)
   const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isActiveRef = useRef(true)
+  /** True while a reported error has not been cleared by a success signal yet */
+  const hasPendingErrorRef = useRef(false)
+  const lastMediaRecoveryAtRef = useRef(Number.NEGATIVE_INFINITY)
+  /** Bumped by retry() to tear down and rebuild the Hls instance */
+  const [reloadToken, setReloadToken] = useState(0)
+  /** Position to resume from when retry() rebuilds the instance */
+  const retryStartPositionRef = useRef<number | null>(null)
 
   const reportError = useEffectEvent((error: HlsPlayerError | null) => {
     onError(error)
@@ -102,6 +116,8 @@ export function useHlsPlayer({
     }
 
     isActiveRef.current = true
+    hasPendingErrorRef.current = false
+    lastMediaRecoveryAtRef.current = Number.NEGATIVE_INFINITY
 
     reportError(null)
     clearRecoveryTimer(recoveryTimerRef)
@@ -111,7 +127,13 @@ export function useHlsPlayer({
     }
 
     if (Hls.isSupported()) {
-      const hls = new Hls(HLS_CONFIG)
+      const retryStartPosition = retryStartPositionRef.current
+      retryStartPositionRef.current = null
+      const hls = new Hls(
+        retryStartPosition !== null && retryStartPosition > 0
+          ? { ...HLS_CONFIG, startPosition: retryStartPosition }
+          : HLS_CONFIG,
+      )
       hls.attachMedia(video)
 
       const handleRecovery = (
@@ -121,10 +143,13 @@ export function useHlsPlayer({
       ) => {
         if (!isActiveRef.current) return
 
+        hasPendingErrorRef.current = true
         reportError(createLocalizedError(type, msgKey, true))
         reportRecoveryStart()
         recoveryFn()
 
+        // Fallback timer: FRAG_BUFFERED / MANIFEST_PARSED normally end the
+        // recovery state as soon as playback actually makes progress again.
         clearRecoveryTimer(recoveryTimerRef)
         recoveryTimerRef.current = setTimeout(() => {
           if (isActiveRef.current) reportRecoveryEnd()
@@ -144,19 +169,45 @@ export function useHlsPlayer({
             )
             break
           case Hls.ErrorTypes.MEDIA_ERROR:
-            handleRecovery('media', 'player.error.media', () =>
-              hls.recoverMediaError(),
-            )
+            handleRecovery('media', 'player.error.media', () => {
+              const now = performance.now()
+              if (
+                now - lastMediaRecoveryAtRef.current <
+                MEDIA_ERROR_SWAP_WINDOW_MS
+              ) {
+                // Second media error shortly after a recovery attempt:
+                // hls.js docs require swapping the audio codec before retrying.
+                hls.swapAudioCodec()
+              }
+              lastMediaRecoveryAtRef.current = now
+              hls.recoverMediaError()
+            })
             break
           default:
+            // Recoverable via the Retry button, which rebuilds the Hls
+            // instance. Marking it non-recoverable would strand the user on
+            // a permanent error overlay with no way out.
+            hasPendingErrorRef.current = true
             reportError(
-              createLocalizedError('unknown', 'player.error.unknown', false),
+              createLocalizedError('unknown', 'player.error.unknown', true),
             )
         }
       }
 
+      const handleFragBuffered = () => {
+        if (!isActiveRef.current || !hasPendingErrorRef.current) return
+        // A fragment appended successfully after an error: playback has
+        // genuinely recovered, so clear the error overlay now instead of
+        // waiting for the blind recovery timer.
+        hasPendingErrorRef.current = false
+        reportError(null)
+        clearRecoveryTimer(recoveryTimerRef)
+        reportRecoveryEnd()
+      }
+
       const handleManifestParsed = () => {
         if (!isActiveRef.current) return
+        hasPendingErrorRef.current = false
         reportError(null)
         clearRecoveryTimer(recoveryTimerRef)
         reportRecoveryEnd()
@@ -164,6 +215,7 @@ export function useHlsPlayer({
 
       hls.on(Hls.Events.ERROR, handleError)
       hls.on(Hls.Events.MANIFEST_PARSED, handleManifestParsed)
+      hls.on(Hls.Events.FRAG_BUFFERED, handleFragBuffered)
 
       hls.loadSource(videoUrl)
       hlsRef.current = hls
@@ -176,6 +228,7 @@ export function useHlsPlayer({
         }
         hls.off(Hls.Events.ERROR, handleError)
         hls.off(Hls.Events.MANIFEST_PARSED, handleManifestParsed)
+        hls.off(Hls.Events.FRAG_BUFFERED, handleFragBuffered)
         hls.destroy()
         if (hlsRef.current === hls) hlsRef.current = null
       }
@@ -194,11 +247,15 @@ export function useHlsPlayer({
         hlsRef.current = null
       }
     }
-  }, [videoUrl])
+  }, [videoUrl, reloadToken])
 
   const retry = () => {
     onError(null)
-    hlsRef.current?.loadSource(videoUrl)
+    // Rebuild the Hls instance from scratch: after a fatal error the current
+    // instance (and its MediaSource) may be beyond repair, so reloading the
+    // source on it is not reliable. Resume from the current position.
+    retryStartPositionRef.current = videoRef.current?.currentTime ?? null
+    setReloadToken((token) => token + 1)
   }
 
   return { videoRef, hlsRef, retry }

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -204,21 +204,23 @@ export function useVideoPlayer({
     onStrategyChange?.(newStrategy)
   }
 
+  // Cleared (null) errors reach the consumer too, so its error overlay is
+  // dismissed (e.g. on retry or when a new source starts loading).
+  const reportVideoError = (videoError: VideoPlayerError | null) => {
+    setError(videoError)
+    onError?.(videoError)
+  }
+
   const handleHlsError = (hlsError: HlsPlayerError | null) => {
-    if (hlsError && isActiveRef.current) {
-      const videoError: VideoPlayerError = {
-        type: hlsError.type === 'network' ? 'network_error' : 'media_error',
-        message: hlsError.message,
-        recoverable: hlsError.recoverable,
-      }
-      setError(videoError)
-      onError?.(videoError)
-    } else {
-      // Propagate the cleared error so the consumer's error overlay is
-      // dismissed too (e.g. on retry or when a new source starts loading).
-      setError(null)
-      onError?.(null)
-    }
+    reportVideoError(
+      hlsError && isActiveRef.current
+        ? {
+            type: hlsError.type === 'network' ? 'network_error' : 'media_error',
+            message: hlsError.message,
+            recoverable: hlsError.recoverable,
+          }
+        : null,
+    )
   }
 
   const handleHlsRecoveryStart = () => onRecoveryStart?.()
@@ -587,8 +589,7 @@ export function useVideoPlayer({
   }, [strategy, videoUrl, itemId])
 
   const retry = () => {
-    setError(null)
-    onError?.(null)
+    reportVideoError(null)
     networkRetryCountRef.current = 0
 
     if (strategy === 'hls') {

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -39,7 +39,7 @@ interface UseVideoPlayerOptions {
   item: BaseItemDto | null
   preferredAudioStreamIndex?: number
   jellyfinPlaybackSyncEnabled?: boolean
-  onError?: (error: VideoPlayerError) => void
+  onError?: (error: VideoPlayerError | null) => void
   onStrategyChange?: (strategy: PlaybackStrategy) => void
   onRecoveryStart?: () => void
   onRecoveryEnd?: () => void
@@ -193,7 +193,10 @@ export function useVideoPlayer({
       setError(videoError)
       onError?.(videoError)
     } else {
+      // Propagate the cleared error so the consumer's error overlay is
+      // dismissed too (e.g. on retry or when a new source starts loading).
       setError(null)
+      onError?.(null)
     }
   }
 
@@ -534,6 +537,7 @@ export function useVideoPlayer({
 
   const retry = () => {
     setError(null)
+    onError?.(null)
     networkRetryCountRef.current = 0
 
     if (strategy === 'hls') {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,11 @@ export const PLAYER_CONFIG = {
   DEFAULT_PLAYBACK_SPEED_INDEX: 3,
   /** Recovery timeout in milliseconds */
   RECOVERY_TIMEOUT_MS: 2000,
+  /**
+   * A repeat fatal media error within this window after a recoverMediaError()
+   * attempt triggers swapAudioCodec() first, per hls.js recovery guidance.
+   */
+  MEDIA_ERROR_SWAP_WINDOW_MS: 3000,
   /** Color extraction timeout in milliseconds */
   COLOR_EXTRACTION_TIMEOUT_MS: 5000,
   /** Resize debounce delay in milliseconds */


### PR DESCRIPTION
Investigating intro-skipper/segment-editor-plugin#7 ("Unexpected playback errors and non-disappearing error message overlay"): the reporter's frozen overlay came from pre-v0.1.24.0 builds whose recovery callbacks were no-ops (fixed by #49), but a live repro against master (mock Jellyfin serving an mkv/h264/mp2 item over fMP4 HLS, with fatal errors driven through the real hls.js emitter) confirmed three remaining ways the overlay still misbehaves. This PR makes the error overlay lifecycle event-driven and Retry trustworthy:

- Propagate cleared errors out of `useVideoPlayer`'s HLS error handler (and `retry()`) so the Player reducer actually dismisses the overlay; previously `onError(null)` was swallowed, so clicking Retry left the overlay up until a manifest happened to re-parse.
- End recovery on the real success signal: `FRAG_BUFFERED` after a reported error now clears the overlay immediately, with the existing `RECOVERY_TIMEOUT_MS` timer kept only as a fallback.
- Make fatal errors outside the network/media classes (`OTHER_ERROR`, e.g. mux errors) recoverable instead of a permanent dead-end overlay: Retry tears down the broken `Hls` instance, rebuilds it, and resumes from the current position via `startPosition`.
- Follow the hls.js recovery contract by calling `swapAudioCodec()` when a second fatal media error arrives within 3s of the last `recoverMediaError()` attempt.

New regression suite (`player-error-recovery.test.tsx`) wires the real `useHlsPlayer` + `useVideoPlayer` + `playerReducer` exactly like `Player.tsx` and drives fake hls.js events to cover: clear-on-FRAG_BUFFERED, timer fallback, retryable unknown errors with instance rebuild + position resume, and the audio-codec swap window (which caught a first-error false positive during development).

Verified live in Chrome against the repro stream: injected fatal media errors now recover without a lingering overlay, and Retry on an unknown fatal dismisses the overlay instantly and resumes playback from the same position.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/e33b8873-8931-443e-8462-2c113b726b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-132" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/e33b8873-8931-443e-8462-2c113b726b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-132&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-132"><img alt="INTRO-132" src="https://capy.ai/api/badge/thread.svg?label=INTRO-132"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Improve HLS playback error recovery so the player error overlay is cleared reliably on real recovery and Retry always resumes playback correctly.

Bug Fixes:
- Ensure cleared errors from the HLS layer propagate through useVideoPlayer so the player error overlay is dismissed when recovery succeeds or Retry is clicked.
- Treat previously terminal unknown fatal HLS errors as recoverable by rebuilding the Hls instance on Retry and resuming from the last playback position.
- Clear the error state immediately when HLS signals successful fragment buffering or manifest parsing after an error, instead of relying solely on a timeout, preventing stuck overlays.

Enhancements:
- Track recent media recovery attempts and call swapAudioCodec for repeated fatal media errors within a short window to follow hls.js recovery guidance.

Tests:
- Add an integrated regression test suite that wires useVideoPlayer, useHlsPlayer, and the player reducer to validate HLS error overlay lifecycle, timer fallback, retry behaviour, and audio codec swap handling.