### PR TITLE
refactor(player): make useVideoPlayer the single owner of error state

### DIFF
--- a/src/__tests__/player-controls-wiring.test.tsx
+++ b/src/__tests__/player-controls-wiring.test.tsx
@@ -17,11 +17,7 @@ type PlayerProps = ComponentProps<typeof Player>
 
 const mocks = vi.hoisted(() => ({
   playerSurfaceProps: [] as Array<unknown>,
-  videoPlayerError: null as null | {
-    type: string
-    message: string
-    recoverable: boolean
-  },
+  videoPlayerError: null as VideoPlayerError | null,
   setShowVideoPlayer: vi.fn(),
   setPreferredAudioLanguage: vi.fn(),
   setPreferredSubtitleLanguage: vi.fn(),
@@ -101,7 +97,7 @@ vi.mock('@/hooks/useBlobUrl', () => ({
 
 vi.mock('@/hooks/use-video-player', () => ({
   useVideoPlayer: () => ({
-    videoRef: mocks.videoRef ?? { current: mocks.videoElement },
+    videoRef: mocks.videoRef,
     hlsRef: { current: null },
     strategy: 'direct',
     isLoading: mocks.videoPlayerIsLoading,
@@ -213,16 +209,20 @@ function createSegment(overrides: Partial<MediaSegmentDto>): MediaSegmentDto {
   }
 }
 
-function renderPlayer(overrides: Partial<PlayerProps> = {}) {
-  return render(
+function playerElement(overrides: Partial<PlayerProps> = {}) {
+  return (
     <Player
       item={createItem()}
       frameStepSeconds={1 / 24}
       onCreateSegment={vi.fn()}
       onUpdateSegmentTimestamp={vi.fn()}
       {...overrides}
-    />,
+    />
   )
+}
+
+function renderPlayer(overrides: Partial<PlayerProps> = {}) {
+  return render(playerElement(overrides))
 }
 
 describe('Player controls wiring', () => {
@@ -289,14 +289,7 @@ describe('Player controls wiring', () => {
       recoverable: true,
     }
     mocks.videoPlayerError = mediaError
-    utils.rerender(
-      <Player
-        item={createItem()}
-        frameStepSeconds={1 / 24}
-        onCreateSegment={vi.fn()}
-        onUpdateSegmentTimestamp={vi.fn()}
-      />,
-    )
+    utils.rerender(playerElement())
 
     surfaceProps = mocks.playerSurfaceProps.at(-1) as PlayerSurfaceProps
     expect(surfaceProps.playback.error).toEqual(mediaError)

--- a/src/__tests__/player-controls-wiring.test.tsx
+++ b/src/__tests__/player-controls-wiring.test.tsx
@@ -17,8 +17,10 @@ type PlayerProps = ComponentProps<typeof Player>
 
 const mocks = vi.hoisted(() => ({
   playerSurfaceProps: [] as Array<unknown>,
-  videoPlayerOptions: null as null | {
-    onError?: (error: unknown) => void
+  videoPlayerError: null as null | {
+    type: string
+    message: string
+    recoverable: boolean
   },
   setShowVideoPlayer: vi.fn(),
   setPreferredAudioLanguage: vi.fn(),
@@ -98,17 +100,16 @@ vi.mock('@/hooks/useBlobUrl', () => ({
 }))
 
 vi.mock('@/hooks/use-video-player', () => ({
-  useVideoPlayer: (options: unknown) => {
-    mocks.videoPlayerOptions = options as typeof mocks.videoPlayerOptions
-    return {
-      videoRef: mocks.videoRef ?? { current: mocks.videoElement },
-      hlsRef: { current: null },
-      strategy: 'direct',
-      isLoading: mocks.videoPlayerIsLoading,
-      retry: mocks.retry,
-      reloadHlsWithUrl: vi.fn(),
-    }
-  },
+  useVideoPlayer: () => ({
+    videoRef: mocks.videoRef ?? { current: mocks.videoElement },
+    hlsRef: { current: null },
+    strategy: 'direct',
+    isLoading: mocks.videoPlayerIsLoading,
+    error: mocks.videoPlayerError,
+    isRecovering: false,
+    retry: mocks.retry,
+    reloadHlsWithUrl: vi.fn(),
+  }),
 }))
 
 vi.mock('@/components/player/use-fullscreen-player-ui', () => ({
@@ -230,7 +231,7 @@ describe('Player controls wiring', () => {
     mocks.playerSurfaceProps = []
     mocks.videoElement = document.createElement('video')
     mocks.videoRef = { current: mocks.videoElement }
-    mocks.videoPlayerOptions = null
+    mocks.videoPlayerError = null
     mocks.trackManagerIsLoading = true
     mocks.videoPlayerIsLoading = true
     mocks.audioSwitchTranscodeScope = 'all'
@@ -243,7 +244,7 @@ describe('Player controls wiring', () => {
   })
 
   it('passes Player state, handlers, and render groups through to PlayerSurface', () => {
-    renderPlayer()
+    const utils = renderPlayer()
 
     let surfaceProps = mocks.playerSurfaceProps.at(-1) as PlayerSurfaceProps
     expect(surfaceProps.fullscreen).toMatchObject({
@@ -287,16 +288,18 @@ describe('Player controls wiring', () => {
       message: 'Playback failed',
       recoverable: true,
     }
-    act(() => {
-      mocks.videoPlayerOptions?.onError?.(mediaError)
-    })
+    mocks.videoPlayerError = mediaError
+    utils.rerender(
+      <Player
+        item={createItem()}
+        frameStepSeconds={1 / 24}
+        onCreateSegment={vi.fn()}
+        onUpdateSegmentTimestamp={vi.fn()}
+      />,
+    )
 
     surfaceProps = mocks.playerSurfaceProps.at(-1) as PlayerSurfaceProps
-    expect(surfaceProps.playback.error).toEqual({
-      type: 'media',
-      message: 'Playback failed',
-      recoverable: true,
-    })
+    expect(surfaceProps.playback.error).toEqual(mediaError)
     surfaceProps.playback.onRetry()
     expect(mocks.retry).toHaveBeenCalledTimes(1)
   })

--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -10,11 +10,9 @@
  */
 
 import { act, render, waitFor } from '@testing-library/react'
-import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BaseItemDto } from '@/types/jellyfin'
-import type { VideoPlayerError } from '@/hooks/use-video-player'
 import { useVideoPlayer } from '@/hooks/use-video-player'
 import { getPlaybackConfig } from '@/services/video/api'
 import type * as VideoApiModule from '@/services/video/api'
@@ -112,39 +110,20 @@ vi.mock('@/services/video/transcode-session', () => ({
   stopActiveEncodingKeepalive: vi.fn(),
 }))
 
-const observed: {
-  error: VideoPlayerError | null
-  isRecovering: boolean
-  retry: () => void
-} = {
-  error: null,
-  isRecovering: false,
-  retry: () => {},
-}
+/** The hook state Player.tsx renders the overlays from, as of the last render. */
+let latest: ReturnType<typeof useVideoPlayer>
 
-/** Exposes the hook state Player.tsx renders the overlays from. */
 function Harness({ item }: { item: BaseItemDto }) {
-  const { error, isRecovering, retry, videoRef } = useVideoPlayer({
+  latest = useVideoPlayer({
     item,
     t: (key: string) => key,
   })
 
-  useEffect(() => {
-    observed.error = error
-    observed.isRecovering = isRecovering
-    observed.retry = retry
-  })
-
   return (
-    <video ref={videoRef} muted>
+    <video ref={latest.videoRef} muted>
       <track kind="captions" />
     </video>
   )
-}
-
-/** Mirrors PlayerSurface's overlay conditions. */
-function errorOverlayVisible() {
-  return Boolean(observed.error && !observed.isRecovering)
 }
 
 function emitHlsEvent(hls: FakeHlsInstance, event: string, data?: unknown) {
@@ -199,17 +178,16 @@ describe('HLS error recovery overlay lifecycle', () => {
     const { hls } = await renderPlayingHarness()
 
     emitHlsEvent(hls, 'hlsError', fatalMediaError)
-    expect(observed.error).not.toBeNull()
-    expect(observed.isRecovering).toBe(true)
+    expect(latest.error).not.toBeNull()
+    expect(latest.isRecovering).toBe(true)
     expect(hls.recoverCalls).toBe(1)
 
     // Playback resumes: a fragment appends successfully well before the
     // fallback recovery timer would have fired.
     emitHlsEvent(hls, 'hlsFragBuffered')
 
-    expect(observed.error).toBeNull()
-    expect(observed.isRecovering).toBe(false)
-    expect(errorOverlayVisible()).toBe(false)
+    expect(latest.error).toBeNull()
+    expect(latest.isRecovering).toBe(false)
   })
 
   it('falls back to the recovery timer when no fragment buffers', async () => {
@@ -217,22 +195,23 @@ describe('HLS error recovery overlay lifecycle', () => {
     vi.useFakeTimers()
 
     emitHlsEvent(hls, 'hlsError', fatalMediaError)
-    expect(observed.isRecovering).toBe(true)
+    expect(latest.isRecovering).toBe(true)
 
     act(() => {
       vi.advanceTimersByTime(2100)
     })
 
-    expect(observed.error).toBeNull()
-    expect(observed.isRecovering).toBe(false)
+    expect(latest.error).toBeNull()
+    expect(latest.isRecovering).toBe(false)
   })
 
   it('keeps unknown fatal errors recoverable and rebuilds the player on retry', async () => {
     const { hls, utils } = await renderPlayingHarness()
 
     emitHlsEvent(hls, 'hlsError', fatalOtherError)
-    expect(errorOverlayVisible()).toBe(true)
-    expect(observed.error?.recoverable).toBe(true)
+    expect(latest.error).not.toBeNull()
+    expect(latest.isRecovering).toBe(false)
+    expect(latest.error?.recoverable).toBe(true)
 
     const video = utils.container.querySelector('video')!
     Object.defineProperty(video, 'currentTime', {
@@ -242,12 +221,11 @@ describe('HLS error recovery overlay lifecycle', () => {
 
     const instancesBefore = hlsState.instances.length
     act(() => {
-      observed.retry()
+      latest.retry()
     })
 
     // The overlay clears immediately on retry...
-    expect(observed.error).toBeNull()
-    expect(errorOverlayVisible()).toBe(false)
+    expect(latest.error).toBeNull()
 
     // ...and a fresh Hls instance reloads the source from the same position.
     await waitFor(() => {
@@ -262,12 +240,12 @@ describe('HLS error recovery overlay lifecycle', () => {
     const { hls } = await renderPlayingHarness()
 
     emitHlsEvent(hls, 'hlsError', fatalOtherError)
-    expect(errorOverlayVisible()).toBe(true)
+    expect(latest.error).not.toBeNull()
 
     emitHlsEvent(hls, 'hlsFragBuffered')
 
-    expect(errorOverlayVisible()).toBe(false)
-    expect(observed.error).toBeNull()
+    expect(latest.error).toBeNull()
+    expect(latest.isRecovering).toBe(false)
   })
 
   it('swaps the audio codec when media errors repeat within the swap window', async () => {

--- a/src/__tests__/player-error-recovery.test.tsx
+++ b/src/__tests__/player-error-recovery.test.tsx
@@ -4,24 +4,18 @@
  * (intro-skipper/segment-editor-plugin#7: error overlay never disappeared
  * after playback recovered).
  *
- * Wires useVideoPlayer (with the real useHlsPlayer) to the real playerReducer
- * exactly like Player.tsx does, and drives hls.js events through a fake.
+ * useVideoPlayer (with the real useHlsPlayer) owns the error/recovery state
+ * the overlay renders from; these tests observe the hook's returned state
+ * directly and drive hls.js events through a fake.
  */
 
 import { act, render, waitFor } from '@testing-library/react'
-import { useEffect, useReducer } from 'react'
+import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BaseItemDto } from '@/types/jellyfin'
 import type { VideoPlayerError } from '@/hooks/use-video-player'
-import type { HlsPlayerError } from '@/hooks/use-hls-player'
 import { useVideoPlayer } from '@/hooks/use-video-player'
-import {
-  initialPlayerState,
-  mapVideoErrorType,
-  playerReducer,
-} from '@/components/player/player-reducer'
-import type { PlayerState } from '@/components/player/player-reducer'
 import { getPlaybackConfig } from '@/services/video/api'
 import type * as VideoApiModule from '@/services/video/api'
 
@@ -118,46 +112,26 @@ vi.mock('@/services/video/transcode-session', () => ({
   stopActiveEncodingKeepalive: vi.fn(),
 }))
 
-const observed: { state: PlayerState; retry: () => void } = {
-  state: initialPlayerState,
+const observed: {
+  error: VideoPlayerError | null
+  isRecovering: boolean
+  retry: () => void
+} = {
+  error: null,
+  isRecovering: false,
   retry: () => {},
 }
 
-/** Replicates the error/recovery wiring between Player.tsx and useVideoPlayer. */
+/** Exposes the hook state Player.tsx renders the overlays from. */
 function Harness({ item }: { item: BaseItemDto }) {
-  const [state, dispatch] = useReducer(playerReducer, initialPlayerState)
-
-  const handleVideoError = (error: VideoPlayerError | null) => {
-    if (error) {
-      const hlsError: HlsPlayerError = {
-        type: mapVideoErrorType(error.type),
-        message: error.message,
-        recoverable: error.recoverable,
-      }
-      dispatch({ type: 'ERROR_STATE', error: hlsError, isRecovering: false })
-    } else {
-      dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
-    }
-  }
-
-  const player = useVideoPlayer({
+  const { error, isRecovering, retry, videoRef } = useVideoPlayer({
     item,
-    onError: handleVideoError,
-    onStrategyChange: () => {
-      dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
-    },
-    onRecoveryStart: () => {
-      dispatch({ type: 'RECOVERY_START' })
-    },
-    onRecoveryEnd: () => {
-      dispatch({ type: 'RECOVERY_END' })
-    },
     t: (key: string) => key,
   })
-  const { retry, videoRef } = player
 
   useEffect(() => {
-    observed.state = state
+    observed.error = error
+    observed.isRecovering = isRecovering
     observed.retry = retry
   })
 
@@ -170,7 +144,7 @@ function Harness({ item }: { item: BaseItemDto }) {
 
 /** Mirrors PlayerSurface's overlay conditions. */
 function errorOverlayVisible() {
-  return Boolean(observed.state.playerError && !observed.state.isRecovering)
+  return Boolean(observed.error && !observed.isRecovering)
 }
 
 function emitHlsEvent(hls: FakeHlsInstance, event: string, data?: unknown) {
@@ -225,16 +199,16 @@ describe('HLS error recovery overlay lifecycle', () => {
     const { hls } = await renderPlayingHarness()
 
     emitHlsEvent(hls, 'hlsError', fatalMediaError)
-    expect(observed.state.playerError).not.toBeNull()
-    expect(observed.state.isRecovering).toBe(true)
+    expect(observed.error).not.toBeNull()
+    expect(observed.isRecovering).toBe(true)
     expect(hls.recoverCalls).toBe(1)
 
     // Playback resumes: a fragment appends successfully well before the
     // fallback recovery timer would have fired.
     emitHlsEvent(hls, 'hlsFragBuffered')
 
-    expect(observed.state.playerError).toBeNull()
-    expect(observed.state.isRecovering).toBe(false)
+    expect(observed.error).toBeNull()
+    expect(observed.isRecovering).toBe(false)
     expect(errorOverlayVisible()).toBe(false)
   })
 
@@ -243,14 +217,14 @@ describe('HLS error recovery overlay lifecycle', () => {
     vi.useFakeTimers()
 
     emitHlsEvent(hls, 'hlsError', fatalMediaError)
-    expect(observed.state.isRecovering).toBe(true)
+    expect(observed.isRecovering).toBe(true)
 
     act(() => {
       vi.advanceTimersByTime(2100)
     })
 
-    expect(observed.state.playerError).toBeNull()
-    expect(observed.state.isRecovering).toBe(false)
+    expect(observed.error).toBeNull()
+    expect(observed.isRecovering).toBe(false)
   })
 
   it('keeps unknown fatal errors recoverable and rebuilds the player on retry', async () => {
@@ -258,7 +232,7 @@ describe('HLS error recovery overlay lifecycle', () => {
 
     emitHlsEvent(hls, 'hlsError', fatalOtherError)
     expect(errorOverlayVisible()).toBe(true)
-    expect(observed.state.playerError?.recoverable).toBe(true)
+    expect(observed.error?.recoverable).toBe(true)
 
     const video = utils.container.querySelector('video')!
     Object.defineProperty(video, 'currentTime', {
@@ -272,7 +246,7 @@ describe('HLS error recovery overlay lifecycle', () => {
     })
 
     // The overlay clears immediately on retry...
-    expect(observed.state.playerError).toBeNull()
+    expect(observed.error).toBeNull()
     expect(errorOverlayVisible()).toBe(false)
 
     // ...and a fresh Hls instance reloads the source from the same position.
@@ -293,7 +267,7 @@ describe('HLS error recovery overlay lifecycle', () => {
     emitHlsEvent(hls, 'hlsFragBuffered')
 
     expect(errorOverlayVisible()).toBe(false)
-    expect(observed.state.playerError).toBeNull()
+    expect(observed.error).toBeNull()
   })
 
   it('swaps the audio codec when media errors repeat within the swap window', async () => {

--- a/src/__tests__/player-surface.test.tsx
+++ b/src/__tests__/player-surface.test.tsx
@@ -306,7 +306,7 @@ describe('PlayerSurface', () => {
 
   it('rounds the error overlay only in windowed mode', () => {
     const error = {
-      type: 'media',
+      type: 'media_error',
       message: 'Playback failed',
       recoverable: false,
     } as const
@@ -366,7 +366,7 @@ describe('PlayerSurface', () => {
           playback: {
             onRetry,
             error: {
-              type: 'media',
+              type: 'media_error',
               message: 'Playback failed',
               recoverable: true,
             },

--- a/src/__tests__/properties/reducer-reference-stability.property.test.ts
+++ b/src/__tests__/properties/reducer-reference-stability.property.test.ts
@@ -17,10 +17,10 @@ import {
 } from '@/components/player/player-reducer'
 import { PLAYER_CONFIG } from '@/lib/constants'
 
-const { SKIP_TIMES } = PLAYER_CONFIG
+const { SKIP_TIMES, PLAYBACK_SPEEDS } = PLAYER_CONFIG
 
 /** Arbitrary for generating valid PlayerState */
-const playerStateArb = fc.record({
+const playerStateArb: fc.Arbitrary<PlayerState> = fc.record({
   isPlaying: fc.boolean(),
   currentTime: fc.float({ min: 0, max: 10000, noNaN: true }),
   duration: fc.float({ min: 0, max: 10000, noNaN: true }),
@@ -28,7 +28,9 @@ const playerStateArb = fc.record({
   volume: fc.float({ min: 0, max: 1, noNaN: true }),
   isMuted: fc.boolean(),
   skipTimeIndex: fc.integer({ min: 0, max: SKIP_TIMES.length - 1 }),
-}) as fc.Arbitrary<PlayerState>
+  subtitleOffset: fc.float({ min: -30, max: 30, noNaN: true }),
+  playbackSpeedIndex: fc.integer({ min: 0, max: PLAYBACK_SPEEDS.length - 1 }),
+})
 
 describe('Reducer Reference Stability', () => {
   /**
@@ -298,7 +300,9 @@ describe('Reducer Reference Stability', () => {
             result.buffered === state.buffered &&
             result.volume === state.volume &&
             result.isMuted === state.isMuted &&
-            result.skipTimeIndex === state.skipTimeIndex
+            result.skipTimeIndex === state.skipTimeIndex &&
+            result.subtitleOffset === state.subtitleOffset &&
+            result.playbackSpeedIndex === state.playbackSpeedIndex
           )
         },
       ),

--- a/src/__tests__/properties/reducer-reference-stability.property.test.ts
+++ b/src/__tests__/properties/reducer-reference-stability.property.test.ts
@@ -28,8 +28,6 @@ const playerStateArb = fc.record({
   volume: fc.float({ min: 0, max: 1, noNaN: true }),
   isMuted: fc.boolean(),
   skipTimeIndex: fc.integer({ min: 0, max: SKIP_TIMES.length - 1 }),
-  playerError: fc.constant(null),
-  isRecovering: fc.boolean(),
 }) as fc.Arbitrary<PlayerState>
 
 describe('Reducer Reference Stability', () => {
@@ -279,43 +277,6 @@ describe('Reducer Reference Stability', () => {
   })
 
   /**
-   * Property: ERROR_STATE always returns new reference (error state changes are always significant)
-   */
-  it('returns new reference for ERROR_STATE action', () => {
-    fc.assert(
-      fc.property(playerStateArb, fc.boolean(), (state, isRecovering) => {
-        const action: PlayerAction = {
-          type: 'ERROR_STATE',
-          error: null,
-          isRecovering,
-        }
-        const result = playerReducer(state, action)
-        // ERROR_STATE always creates new object (no optimization for error state)
-        return (
-          result !== state ||
-          (result.playerError === null && result.isRecovering === isRecovering)
-        )
-      }),
-      { numRuns: 100 },
-    )
-  })
-
-  /**
-   * Property: RECOVERY_START always returns new reference
-   */
-  it('returns new reference for RECOVERY_START action', () => {
-    fc.assert(
-      fc.property(playerStateArb, (state) => {
-        const action: PlayerAction = { type: 'RECOVERY_START' }
-        const result = playerReducer(state, action)
-        // RECOVERY_START always creates new object
-        return result !== state || result.isRecovering === true
-      }),
-      { numRuns: 100 },
-    )
-  })
-
-  /**
    * Property: State values are preserved for unchanged fields
    * When an action changes one field, all other fields should remain unchanged.
    */
@@ -337,9 +298,7 @@ describe('Reducer Reference Stability', () => {
             result.buffered === state.buffered &&
             result.volume === state.volume &&
             result.isMuted === state.isMuted &&
-            result.skipTimeIndex === state.skipTimeIndex &&
-            result.playerError === state.playerError &&
-            result.isRecovering === state.isRecovering
+            result.skipTimeIndex === state.skipTimeIndex
           )
         },
       ),

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -13,11 +13,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { PlayerScrubber } from './PlayerScrubber'
 import { PlayerSurface } from './PlayerSurface'
 import type { PlayerControlsProps } from './PlayerControls'
-import {
-  initialPlayerState,
-  mapVideoErrorType,
-  playerReducer,
-} from './player-reducer'
+import { initialPlayerState, playerReducer } from './player-reducer'
 import {
   buildSegmentTimeIndex,
   findActiveSegmentRange,
@@ -31,8 +27,6 @@ import type {
   MediaSegmentDto,
   MediaSegmentType,
 } from '@/types/jellyfin'
-import type { VideoPlayerError } from '@/hooks/use-video-player'
-import type { HlsPlayerError } from '@/hooks/use-hls-player'
 import type { CreateSegmentData, TimestampUpdate } from '@/types/segment'
 import type { PlaybackStrategy } from '@/services/video/api'
 import { getBestImageUrl } from '@/services/video/api'
@@ -234,8 +228,6 @@ function useRenderPlayer({
     volume,
     isMuted,
     skipTimeIndex,
-    playerError,
-    isRecovering,
     subtitleOffset,
     playbackSpeedIndex,
   } = state
@@ -323,22 +315,7 @@ function useRenderPlayer({
   const rawPosterUrl = getBestImageUrl(item, 900, 506) ?? null
   const posterUrl = useBlobUrl(rawPosterUrl)
 
-  const handleVideoError = (error: VideoPlayerError | null) => {
-    if (error) {
-      const hlsError: HlsPlayerError = {
-        type: mapVideoErrorType(error.type),
-        message: error.message,
-        recoverable: error.recoverable,
-      }
-      dispatch({ type: 'ERROR_STATE', error: hlsError, isRecovering: false })
-    } else {
-      dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
-    }
-  }
-
   const handleStrategyChange = (strategy: PlaybackStrategy) => {
-    dispatch({ type: 'ERROR_STATE', error: null, isRecovering: false })
-
     if (previousStrategyRef.current === 'direct' && strategy === 'hls') {
       showNotification({
         type: 'info',
@@ -361,6 +338,8 @@ function useRenderPlayer({
     hlsRef,
     strategy,
     isLoading: isVideoLoading,
+    error: playerError,
+    isRecovering,
     retry: handleRetry,
     reloadHlsWithUrl,
   } = useVideoPlayer({
@@ -376,14 +355,7 @@ function useRenderPlayer({
       findItemPreferredAudioStreamIndex(item, readPreferredAudioLanguage()),
     getCurrentAudioStreamIndex: () => currentAudioStreamIndexRef.current,
     jellyfinPlaybackSyncEnabled,
-    onError: handleVideoError,
     onStrategyChange: handleStrategyChange,
-    onRecoveryStart: () => {
-      dispatch({ type: 'RECOVERY_START' })
-    },
-    onRecoveryEnd: () => {
-      dispatch({ type: 'RECOVERY_END' })
-    },
     t,
   })
 

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -358,6 +358,7 @@ function useRenderPlayer({
     onStrategyChange: handleStrategyChange,
     t,
   })
+  const hasPlayerError = playerError !== null
 
   const {
     setPreferredAudioLanguage,
@@ -929,7 +930,7 @@ function useRenderPlayer({
         onRetry: handleRetry,
       }}
       segmentSkip={
-        segmentSkipMode === 'button' && playerError === null && !isVideoLoading
+        segmentSkipMode === 'button' && !hasPlayerError && !isVideoLoading
           ? activeSkipSegment
             ? { segment: activeSkipSegment, onSkipSegment: handleSkipSegment }
             : null

--- a/src/components/player/PlayerSurface.tsx
+++ b/src/components/player/PlayerSurface.tsx
@@ -20,7 +20,7 @@ import type { VideoFitMode } from './use-fullscreen-player-ui'
 import type { PlayerControlsProps } from './PlayerControls'
 import type { NativeCaptionTrack } from './caption-tracks'
 import type { MediaSegmentDto } from '@/types/jellyfin'
-import type { HlsPlayerError } from '@/hooks/use-hls-player'
+import type { VideoPlayerError } from '@/hooks/use-video-player'
 import type { PlaybackStrategy } from '@/services/video/api'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -49,7 +49,7 @@ interface PlayerSurfaceVideoState {
 }
 
 interface PlayerSurfacePlaybackState {
-  error: HlsPlayerError | null
+  error: VideoPlayerError | null
   isRecovering: boolean
   strategy: PlaybackStrategy
   isVideoLoading: boolean
@@ -159,7 +159,7 @@ function PlayerVideoButton({
 }
 
 interface PlayerErrorOverlayProps {
-  error: HlsPlayerError
+  error: VideoPlayerError
   strategy: PlaybackStrategy
   isFullscreen: boolean
   onRetry: () => void
@@ -186,7 +186,7 @@ function PlayerErrorOverlay({
         aria-hidden="true"
       />
       <p className="text-lg font-medium mb-2">{error.message}</p>
-      {strategy === 'direct' && error.type === 'media' ? (
+      {strategy === 'direct' && error.type === 'media_error' ? (
         <p className="text-sm text-muted-foreground mb-2">
           {t('player.error.directPlayFailed')}
         </p>

--- a/src/components/player/player-reducer.ts
+++ b/src/components/player/player-reducer.ts
@@ -3,8 +3,6 @@
  * Extracted for testability and separation of concerns.
  */
 
-import type { HlsPlayerError } from '@/hooks/use-hls-player'
-import type { VideoPlayerErrorType } from '@/hooks/use-video-player'
 import { PLAYER_CONFIG } from '@/lib/constants'
 
 const {
@@ -26,8 +24,6 @@ export interface PlayerState {
   volume: number
   isMuted: boolean
   skipTimeIndex: number
-  playerError: HlsPlayerError | null
-  isRecovering: boolean
   /** User-configured subtitle offset in seconds (positive = delay, negative = advance) */
   subtitleOffset: number
   /** Current index into PLAYBACK_SPEEDS array */
@@ -42,27 +38,10 @@ export type PlayerAction =
   | { type: 'PLAY_STATE'; isPlaying: boolean }
   | { type: 'VOLUME_CHANGE'; volume: number; isMuted: boolean }
   | { type: 'SKIP_TIME_CHANGE'; skipTimeIndex: number }
-  | { type: 'ERROR_STATE'; error: HlsPlayerError | null; isRecovering: boolean }
-  | { type: 'RECOVERY_START' }
-  | { type: 'RECOVERY_END' }
   | { type: 'CYCLE_SKIP'; direction: 1 | -1 }
   | { type: 'SUBTITLE_OFFSET_CHANGE'; offset: number }
   | { type: 'CYCLE_SPEED'; direction: 1 | -1 }
   | { type: 'SET_SPEED'; speedIndex: number }
-
-/** Maps useVideoPlayer error types onto the reducer's HlsPlayerError taxonomy. */
-export function mapVideoErrorType(
-  type: VideoPlayerErrorType,
-): HlsPlayerError['type'] {
-  switch (type) {
-    case 'media_error':
-      return 'media'
-    case 'network_error':
-      return 'network'
-    default:
-      return 'unknown'
-  }
-}
 
 export const initialPlayerState: PlayerState = {
   isPlaying: false,
@@ -72,8 +51,6 @@ export const initialPlayerState: PlayerState = {
   volume: 1,
   isMuted: false,
   skipTimeIndex: DEFAULT_SKIP_TIME_INDEX,
-  playerError: null,
-  isRecovering: false,
   subtitleOffset: 0,
   playbackSpeedIndex: DEFAULT_PLAYBACK_SPEED_INDEX,
 }
@@ -116,24 +93,6 @@ export function playerReducer(
       return state.skipTimeIndex === action.skipTimeIndex
         ? state
         : { ...state, skipTimeIndex: action.skipTimeIndex }
-
-    case 'ERROR_STATE':
-      return state.playerError === action.error &&
-        state.isRecovering === action.isRecovering
-        ? state
-        : {
-            ...state,
-            playerError: action.error,
-            isRecovering: action.isRecovering,
-          }
-
-    case 'RECOVERY_START':
-      return state.isRecovering ? state : { ...state, isRecovering: true }
-
-    case 'RECOVERY_END':
-      return !state.isRecovering && state.playerError === null
-        ? state
-        : { ...state, isRecovering: false, playerError: null }
 
     case 'CYCLE_SKIP': {
       const newIndex = Math.max(

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -22,7 +22,7 @@ import { useJellyfinSession } from '@/hooks/use-jellyfin-session'
 import type { JellyfinSessionDescriptor } from '@/hooks/use-jellyfin-session'
 import { usePlaybackStatePreservation } from '@/hooks/use-playback-state-preservation'
 
-export type VideoPlayerErrorType =
+type VideoPlayerErrorType =
   | 'media_error'
   | 'network_error'
   | 'source_error'
@@ -200,12 +200,23 @@ export function useVideoPlayer({
     onStrategyChange?.(newStrategy)
   }
 
-  // Single owner of the error state the consumer renders from. Any reported
-  // error (or clear) also ends a recovery in progress: a fresh fatal error
-  // must surface immediately instead of staying suppressed behind the
-  // recovery spinner, and a clear means playback is healthy again.
+  // Single owner of the error state the consumer renders from. Reporting or
+  // clearing an error also resets the recovery flag; for recoverable fatal
+  // HLS errors useHlsPlayer re-raises it via onRecoveryStart in the same
+  // batch, so only non-recoverable errors actually clear the spinner. The
+  // previous reference is kept when the contents are unchanged so repeated
+  // identical errors (e.g. hls.js re-emitting a fatal network error per
+  // retry) cannot re-render the player tree.
   const reportVideoError = (videoError: VideoPlayerError | null) => {
-    setError(videoError)
+    setError((previous) =>
+      previous &&
+      videoError &&
+      previous.type === videoError.type &&
+      previous.message === videoError.message &&
+      previous.recoverable === videoError.recoverable
+        ? previous
+        : videoError,
+    )
     setIsRecovering(false)
   }
 
@@ -213,7 +224,12 @@ export function useVideoPlayer({
     reportVideoError(
       hlsError && isActiveRef.current
         ? {
-            type: hlsError.type === 'network' ? 'network_error' : 'media_error',
+            type:
+              hlsError.type === 'network'
+                ? 'network_error'
+                : hlsError.type === 'media'
+                  ? 'media_error'
+                  : 'unknown_error',
             message: hlsError.message,
             recoverable: hlsError.recoverable,
           }
@@ -222,13 +238,11 @@ export function useVideoPlayer({
   }
 
   const handleHlsRecoveryStart = () => setIsRecovering(true)
-  // Recovery ending also clears the error: the fallback recovery timer in
-  // useHlsPlayer only reports the end, so without this clear a recovered
-  // session would keep showing the stale error overlay.
-  const handleHlsRecoveryEnd = () => {
-    setIsRecovering(false)
-    setError(null)
-  }
+  // Recovery ending means playback is healthy, including via the fallback
+  // recovery timer in useHlsPlayer, which reports only the end - so the
+  // error must be cleared here or a recovered session would keep showing
+  // the stale error overlay.
+  const handleHlsRecoveryEnd = () => reportVideoError(null)
 
   const hlsPlayer = useHlsPlayer({
     videoUrl: strategy === 'hls' ? videoUrl : '',
@@ -671,10 +685,11 @@ export function useVideoPlayer({
   const activeHlsRef = strategy === 'hls' ? hlsPlayer.hlsRef : emptyHlsRef
 
   const isLoading = !!itemId && loadedItemId !== itemId
-  const effectiveError = !itemId || isLoading ? null : error
-  // Gated like the error so a torn-down session's recovery flag can never
-  // leak into a new item's load window.
-  const effectiveIsRecovering = !itemId || isLoading ? false : isRecovering
+  // Fault state is scoped to a loaded session so a torn-down session's
+  // error or recovery flag can never leak into a new item's load window.
+  const hasLoadedSession = !!itemId && !isLoading
+  const effectiveError = hasLoadedSession ? error : null
+  const effectiveIsRecovering = hasLoadedSession && isRecovering
   const effectiveVideoUrl = !itemId ? '' : videoUrl
 
   return {

--- a/src/hooks/use-video-player.ts
+++ b/src/hooks/use-video-player.ts
@@ -52,10 +52,7 @@ interface UseVideoPlayerOptions {
    */
   getCurrentAudioStreamIndex?: () => number | undefined
   jellyfinPlaybackSyncEnabled?: boolean
-  onError?: (error: VideoPlayerError | null) => void
   onStrategyChange?: (strategy: PlaybackStrategy) => void
-  onRecoveryStart?: () => void
-  onRecoveryEnd?: () => void
   t: (key: string) => string
 }
 
@@ -65,6 +62,7 @@ interface UseVideoPlayerReturn {
   strategy: PlaybackStrategy
   isLoading: boolean
   error: VideoPlayerError | null
+  isRecovering: boolean
   retry: () => void
   videoUrl: string
   reloadHlsWithUrl: (reload: HlsReloadRequest) => Promise<void>
@@ -139,10 +137,7 @@ export function useVideoPlayer({
   getInitialAudioStreamIndex,
   getCurrentAudioStreamIndex,
   jellyfinPlaybackSyncEnabled = false,
-  onError,
   onStrategyChange,
-  onRecoveryStart,
-  onRecoveryEnd,
   t,
 }: UseVideoPlayerOptions): UseVideoPlayerReturn {
   'use memo'
@@ -150,6 +145,7 @@ export function useVideoPlayer({
   const [strategy, setStrategy] = useState<PlaybackStrategy>('hls')
   const [videoUrl, setVideoUrl] = useState('')
   const [error, setError] = useState<VideoPlayerError | null>(null)
+  const [isRecovering, setIsRecovering] = useState(false)
   const [loadedItemId, setLoadedItemId] = useState<string | undefined>(
     undefined,
   )
@@ -204,11 +200,13 @@ export function useVideoPlayer({
     onStrategyChange?.(newStrategy)
   }
 
-  // Cleared (null) errors reach the consumer too, so its error overlay is
-  // dismissed (e.g. on retry or when a new source starts loading).
+  // Single owner of the error state the consumer renders from. Any reported
+  // error (or clear) also ends a recovery in progress: a fresh fatal error
+  // must surface immediately instead of staying suppressed behind the
+  // recovery spinner, and a clear means playback is healthy again.
   const reportVideoError = (videoError: VideoPlayerError | null) => {
     setError(videoError)
-    onError?.(videoError)
+    setIsRecovering(false)
   }
 
   const handleHlsError = (hlsError: HlsPlayerError | null) => {
@@ -223,8 +221,14 @@ export function useVideoPlayer({
     )
   }
 
-  const handleHlsRecoveryStart = () => onRecoveryStart?.()
-  const handleHlsRecoveryEnd = () => onRecoveryEnd?.()
+  const handleHlsRecoveryStart = () => setIsRecovering(true)
+  // Recovery ending also clears the error: the fallback recovery timer in
+  // useHlsPlayer only reports the end, so without this clear a recovered
+  // session would keep showing the stale error overlay.
+  const handleHlsRecoveryEnd = () => {
+    setIsRecovering(false)
+    setError(null)
+  }
 
   const hlsPlayer = useHlsPlayer({
     videoUrl: strategy === 'hls' ? videoUrl : '',
@@ -306,7 +310,7 @@ export function useVideoPlayer({
       if (isCurrentHlsRequest()) {
         const hlsUrl = config.strategy === 'hls' ? config.url : ''
 
-        setError(null)
+        reportVideoError(null)
         updateStrategy('hls')
         setVideoUrl(hlsUrl || config.url)
         setJellyfinSessionIdentity(
@@ -344,8 +348,7 @@ export function useVideoPlayer({
     const videoError = createErrorFromMediaError(mediaError, t)
 
     if (videoError.type === 'media_error') {
-      setError(videoError)
-      onError?.(videoError)
+      reportVideoError(videoError)
       await switchToHls(requestId)
       return
     }
@@ -357,14 +360,12 @@ export function useVideoPlayer({
         return
       }
 
-      setError(videoError)
-      onError?.(videoError)
+      reportVideoError(videoError)
       await switchToHls(requestId)
       return
     }
 
-    setError(videoError)
-    onError?.(videoError)
+    reportVideoError(videoError)
     await switchToHls(requestId)
   })
 
@@ -373,7 +374,7 @@ export function useVideoPlayer({
       config: { strategy: PlaybackStrategy; url: string },
       initializedItemId: string,
     ) => {
-      setError(null)
+      reportVideoError(null)
       updateStrategy(config.strategy)
       setVideoUrl(config.url)
       setLoadedItemId(initializedItemId)
@@ -394,9 +395,8 @@ export function useVideoPlayer({
         recoverable: false,
         originalError: err instanceof Error ? err : undefined,
       }
-      setError(videoError)
+      reportVideoError(videoError)
       setLoadedItemId(failedItemId)
-      onError?.(videoError)
     },
   )
 
@@ -633,7 +633,7 @@ export function useVideoPlayer({
       if (!isCurrentReloadRequest()) return
     }
 
-    setError(null)
+    reportVideoError(null)
 
     if (currentStrategyRef.current === 'direct') {
       // Mark the switch as intentional so handleDirectPlayError ignores the
@@ -672,6 +672,9 @@ export function useVideoPlayer({
 
   const isLoading = !!itemId && loadedItemId !== itemId
   const effectiveError = !itemId || isLoading ? null : error
+  // Gated like the error so a torn-down session's recovery flag can never
+  // leak into a new item's load window.
+  const effectiveIsRecovering = !itemId || isLoading ? false : isRecovering
   const effectiveVideoUrl = !itemId ? '' : videoUrl
 
   return {
@@ -680,6 +683,7 @@ export function useVideoPlayer({
     strategy,
     isLoading,
     error: effectiveError,
+    isRecovering: effectiveIsRecovering,
     retry,
     videoUrl: effectiveVideoUrl,
     reloadHlsWithUrl,


### PR DESCRIPTION
## Summary

Playback error state previously lived in **three synchronized copies**:

1. `useVideoPlayer`'s internal `useState` — whose returned `error` Player.tsx never read
2. the `onError` / `onRecoveryStart` / `onRecoveryEnd` callback relay
3. the reducer's `playerError` / `isRecovering` mirror, which actually drove the overlays

This PR deletes copies 2 and 3. The hook now also owns recovery state (`isRecovering` was previously fire-and-forget callbacks with no state behind them) and returns both fields; Player.tsx passes them straight through to PlayerSurface. The reducer's `ERROR_STATE`/`RECOVERY_START`/`RECOVERY_END` actions and the `mapVideoErrorType` Video→Hls re-mapping are gone — PlayerSurface renders the hook's `VideoPlayerError` taxonomy directly.

All error mutations inside the hook now flow through a single `reportVideoError` funnel, which also ends any recovery in progress (preserving the old `ERROR_STATE { isRecovering: false }` semantics for fatal errors arriving mid-recovery). The recovery-end handler clears the error, preserving the old `RECOVERY_END` semantics for the fallback-timer path.

## Behavior changes

- **Error overlay no longer persists across a new item load**: the hook's returned error is gated on `isLoading` (the loading overlay covers that window, and a new load should dismiss a stale error).
- **Bug fix**: an hls→hls audio reload now clears a visible error overlay. Previously the reducer copy went stale because it was only cleared via `onStrategyChange`, which does not fire on hls→hls reloads — the hook cleared its own (unread) error while the overlay kept showing.

## Tests

- `player-error-recovery.test.tsx`: the harness dropped its verbatim copy of Player's reducer wiring and now observes the hook's returned state — the thing PlayerSurface actually renders from.
- `reducer-reference-stability.property.test.ts`: dropped the properties for the deleted actions/fields.
- `player-controls-wiring.test.tsx`: the `useVideoPlayer` mock now returns `error`/`isRecovering`; the error pass-through is driven by the mock's return value instead of the deleted `onError` option.
- `player-surface.test.tsx`: fixtures use the `VideoPlayerError` taxonomy (`media_error`).

## Verification

- Full suite: 82 files / 699 tests pass; `tsc --noEmit`, oxlint, oxfmt clean
- React Compiler: `use-video-player.ts`, `Player.tsx`, `PlayerSurface.tsx` all transform under `babel-plugin-react-compiler` with `panicThreshold: all_errors` (vitest runs uncompiled, so this was checked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify video playback error and recovery handling so useVideoPlayer becomes the single source of truth for error state, and wire that state directly into Player and PlayerSurface overlays.

Bug Fixes:
- Ensure HLS-to-HLS audio reloads clear any visible playback error overlay instead of leaving stale errors on screen.

Enhancements:
- Expose error and recovery flags directly from useVideoPlayer and gate them on loading state so new item loads always dismiss stale overlays.
- Simplify Player reducer and wiring by removing error/recovery-specific state, actions, and type mapping in favor of the hook’s VideoPlayerError taxonomy.
- Update PlayerSurface to render error overlays using VideoPlayerError semantics (e.g., media_error) instead of HlsPlayerError.

Tests:
- Refocus player-error-recovery tests to observe useVideoPlayer’s returned error/recovery state rather than reducer wiring.
- Remove property-based tests tied to the deleted reducer error/recovery actions and fields.
- Adjust player-controls-wiring tests to drive error pass-through via useVideoPlayer’s returned error state instead of onError callbacks.
- Update PlayerSurface tests to assert against the new VideoPlayerError type naming.