### PR TITLE
fix(segments): read from the core endpoint so segments load again

### DIFF
--- a/src/__tests__/segment-read-endpoint.test.ts
+++ b/src/__tests__/segment-read-endpoint.test.ts
@@ -1,9 +1,13 @@
 /**
- * The editor reads segments from Intro-Skipper's `MediaSegmentsApi/{itemId}` endpoint, never from
- * Jellyfin's core `/MediaSegments/{itemId}`. The core endpoint shapes its response for playback:
- * Intro-Skipper's first-episode filter strips intros from season premieres, and Jellyfin hides
- * segments whose provider the library has disabled. Reading it made a saved intro on a season
- * premiere permanently invisible in the editor (segment-editor-plugin issue #16).
+ * The editor reads segments from Jellyfin's core `/MediaSegments/{itemId}`.
+ *
+ * Commit 3a3de4e pointed this read at Intro-Skipper's `MediaSegmentsApi/{itemId}` to escape the
+ * playback filtering that hides premiere intros (segment-editor-plugin issue #16). No released
+ * plugin serves a GET there, so it answered 405 and the editor loaded nothing (issue #17). The
+ * unfiltered read returns as Phase 1 of docs/plans/plugin-api-integration.md, behind the Phase 0
+ * capability probe and parsing the bare array that endpoint actually returns.
+ *
+ * These pin the endpoint and the tick conversion so the read cannot be repointed by accident.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -23,60 +27,78 @@ vi.mock('@/services/jellyfin', () => ({
 }))
 
 const ITEM_ID = '6872cc2e33a9909b7b2d07ab03abcb03'
+const CORE_URL = `http://localhost:8096/MediaSegments/${ITEM_ID}`
+
+const PREMIERE_INTRO = {
+  Id: '48f9667b0b42490b87d894b18122349d',
+  ItemId: ITEM_ID,
+  Type: 'Intro',
+  StartTicks: 4186000000,
+  EndTicks: 5150800000,
+}
+
+const OUTRO = {
+  Id: '58f9667b0b42490b87d894b18122349d',
+  ItemId: ITEM_ID,
+  Type: 'Outro',
+  StartTicks: 34789200000,
+  EndTicks: 35457600000,
+}
+
+const segmentsResponse = (segments: Array<unknown>) =>
+  new Response(
+    JSON.stringify({ Items: segments, TotalRecordCount: segments.length }),
+    { status: 200 },
+  )
 
 describe('segment read endpoint', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('reads through the editor endpoint, not the playback-shaped core endpoint', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ Items: [], TotalRecordCount: 0 }), {
-        status: 200,
-      }),
-    )
+  it('reads the core endpoint, which every supported plugin serves', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => segmentsResponse([]))
 
     await getSegmentsById(ITEM_ID)
 
-    const [url, init] = fetchMock.mock.calls[0]
-    expect(String(url)).toBe(
-      `http://localhost:8096/MediaSegmentsApi/${ITEM_ID}`,
-    )
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([CORE_URL])
+    const [, init] = fetchMock.mock.calls[0]
     expect(init?.method).toBe('GET')
     expect(init?.headers).toMatchObject({
       Authorization: 'MediaBrowser Token="test-token"',
     })
   })
 
-  it('returns an intro saved on a season premiere, converted to UI seconds', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          Items: [
-            {
-              Id: '48f9667b0b42490b87d894b18122349d',
-              ItemId: ITEM_ID,
-              Type: 'Intro',
-              StartTicks: 4186000000,
-              EndTicks: 5150800000,
-            },
-            {
-              Id: '58f9667b0b42490b87d894b18122349d',
-              ItemId: ITEM_ID,
-              Type: 'Outro',
-              StartTicks: 34789200000,
-              EndTicks: 35457600000,
-            },
-          ],
-          TotalRecordCount: 2,
-        }),
-        { status: 200 },
-      ),
+  it('converts every segment to UI seconds and preserves order', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      segmentsResponse([PREMIERE_INTRO, OUTRO]),
     )
 
     const segments = await getSegmentsById(ITEM_ID)
 
     expect(segments.map((s) => s.Type)).toEqual(['Intro', 'Outro'])
     expect(segments[0]).toMatchObject({ StartTicks: 418.6, EndTicks: 515.08 })
+    expect(segments[1]).toMatchObject({
+      StartTicks: 3478.92,
+      EndTicks: 3545.76,
+    })
+  })
+
+  it('returns an empty list when the response carries no Items', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response(JSON.stringify({}), { status: 200 }),
+    )
+
+    await expect(getSegmentsById(ITEM_ID)).resolves.toEqual([])
+  })
+
+  it('surfaces a failed read instead of reporting no segments', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response(null, { status: 500 }),
+    )
+
+    await expect(getSegmentsById(ITEM_ID)).rejects.toThrow()
   })
 })

--- a/src/services/segments/api.ts
+++ b/src/services/segments/api.ts
@@ -85,9 +85,13 @@ const validateForDelete = (segment: MediaSegmentDto): boolean => {
 // API Operations (Using withApi Pattern Consistently)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Builds segment API endpoint path with proper encoding */
+/** Builds the Intro-Skipper write endpoint path with proper encoding */
 const buildSegmentEndpoint = (path: string): string =>
   `MediaSegmentsApi/${path}`
+
+/** Builds Jellyfin's core segment endpoint path (reads only; writes go to the plugin) */
+const buildCoreSegmentEndpoint = (path: string): string =>
+  `MediaSegments/${path}`
 
 /** Executes segment mutation with retry logic */
 const withSegmentRetry = <T>(
@@ -96,11 +100,18 @@ const withSegmentRetry = <T>(
 ): Promise<T | false> => withRetryOrFalse(fn, getRetryOptions(options))
 
 /**
- * Reads an item's segments through Intro-Skipper's editor endpoint rather than Jellyfin's
- * `/MediaSegments/{itemId}`. The core endpoint shapes its response for playback: Intro-Skipper's
- * first-episode filter strips intros from season premieres, and Jellyfin hides segments whose
- * provider the library has disabled. Authoring needs the stored truth, so it must not read a
- * response that has been filtered for players.
+ * Reads an item's segments from Jellyfin's core endpoint.
+ *
+ * That response is shaped for playback: Intro-Skipper's first-episode filter strips intros from
+ * season premieres, and Jellyfin hides segments whose provider the library has disabled, so a
+ * saved premiere intro is invisible here (segment-editor-plugin issue #16).
+ *
+ * Reading Intro-Skipper's unfiltered `GET MediaSegmentsApi/{itemId}` instead is Phase 1 of
+ * docs/plans/plugin-api-integration.md and waits on the Phase 0 capability probe. Two traps make
+ * the swap unsafe without it: no released plugin serves that route, so it answers 405 and every
+ * read fails (issue #17), and the implementation on the plugin's `expand-segment-editor-workflows`
+ * branch returns a bare array rather than this `{ Items }` envelope, which would parse as zero
+ * segments and feed an empty delete baseline into `batchSaveSegments`.
  */
 export async function getSegmentsById(
   itemId: string,
@@ -112,7 +123,7 @@ export async function getSegmentsById(
     const data = await jellyfinFetchJson<{ Items?: Array<MediaSegmentDto> }>({
       accessToken: apis.api.accessToken,
       baseUrl: apis.api.basePath,
-      endpoint: buildSegmentEndpoint(encodeUrlParam(itemId)),
+      endpoint: buildCoreSegmentEndpoint(encodeUrlParam(itemId)),
       method: 'GET',
       signal: options?.signal,
       timeout: options?.timeout ?? API_CONFIG.SEGMENT_TIMEOUT_MS,

--- a/tools/server.mjs
+++ b/tools/server.mjs
@@ -651,12 +651,14 @@ const server = http.createServer(async (req, res) => {
     return json(res, { Items: segs, TotalRecordCount: segs.length })
   }
 
-  // Segment editor API (intro-skipper style). The editor reads here rather than through
-  // /MediaSegments, whose response the real server shapes for playback.
+  // Segment editor API (intro-skipper style). Writes only, mirroring every released plugin:
+  // the route is registered for POST and DELETE, so a GET answers 405. Serving a GET here
+  // instead let commit 3a3de4e point the editor's read at a route no real server has
+  // (segment-editor-plugin issue #17). The unfiltered editor read arrives with Phase 1 of
+  // docs/plans/plugin-api-integration.md, which specifies a bare EditorSegmentDto[] body.
   m = /^\/MediaSegmentsApi\/([0-9a-f-]+)$/i.exec(p)
   if (m && req.method === 'GET') {
-    const segs = segmentsByItem.get(m[1].replace(/-/g, '')) ?? []
-    return json(res, { Items: segs, TotalRecordCount: segs.length })
+    return json(res, { error: 'Method Not Allowed' }, 405)
   }
   if (m && req.method === 'POST') {
     let body = ''


### PR DESCRIPTION
The editor loads no segments at all. It renders "Something went wrong" and DevTools shows the list query failing with 405 on `GET /MediaSegmentsApi/{itemId}`. Reported in intro-skipper/segment-editor-plugin#17 against Jellyfin 10.11.11 with Intro Skipper 1.10.11.22.

Commit 3a3de4e moved the read to that route to escape the playback filtering that hides premiere intros. No released plugin serves a GET there. `SegmentEditorController` registers the route for POST and DELETE only, so the path matches but the verb does not and ASP.NET answers 405. Writes were unaffected, which is why saving still worked.

## What this does

Reads Jellyfin's core `/MediaSegments/{itemId}` again. That response is still shaped for playback, so premiere intros stay hidden until the unfiltered read arrives as Phase 1 of `docs/plans/plugin-api-integration.md`, behind the Phase 0 capability probe.

I did not add a probe-and-fallback, because it would have failed twice over. The editor read implemented on the plugin's `expand-segment-editor-workflows` branch returns a bare array, not the core `{ Items }` envelope. Parsing it as `{ Items }` yields zero segments, caches itself as working, and hands `batchSaveSegments` an empty delete baseline, so every save recreates the segments as duplicates with no error shown.

`tools/server.mjs` now answers 405 on that route like every released plugin. It had been serving the editor GET, which is why local runs stayed green while every user was broken. Phase 0 adds the `MOCK_EDITOR_API` switch that lets the mock serve the real editor shape.

## Tests

The previous test asserted the URL the code itself built, so it agreed with the code no matter which endpoint it pointed at. Replaced with four cases: the core endpoint and auth header, a two-segment payload asserting order and tick conversion on both elements, an absent `Items` array, and a 500 that propagates rather than reporting an empty list.

704 tests across 84 files pass. `tsc --noEmit`, `oxlint` and `oxfmt --check` are clean.

Fixes intro-skipper/segment-editor-plugin#17

## Summary by Sourcery

Restore editor segment reads by using the supported Jellyfin core endpoint and align the mock server and tests with production behavior.

Bug Fixes:
- Restore segment loading by reading item segments from Jellyfin’s core endpoint while retaining plugin-backed writes.
- Return a method-not-allowed response from the mock plugin read route to match released plugin behavior.

Enhancements:
- Expand segment-read coverage for endpoint selection, authentication, multi-segment conversion, malformed successful responses, and failed requests.

Tests:
- Replace endpoint-coupled tests with coverage that verifies the core read endpoint, ordering, tick conversion, empty responses, and error propagation.