### PR TITLE
feat(player): step to the previous or next episode from the header

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,11 +11,11 @@ The header control on the player page that shows the current episode's title and
 _Avoid_: Episode dropdown, episode picker
 
 **Series Order**:
-The sequence of a series' playable episodes: regular seasons ascending by season number, episodes ascending within each season. Specials are not part of Series Order.
+The sequence of a series' playable episodes: regular seasons ascending by season number, then Specials, with episodes ascending within each season. It matches the order of the season tabs on the series page.
 _Avoid_: Playback order, air order
 
 **Adjacent Episode**:
-The episode immediately before or after the current one in Series Order, crossing season boundaries. A Special's adjacent episodes are the neighbouring Specials only. The first and last episodes have no previous or next adjacent episode respectively.
+The episode immediately before or after the current one in Series Order, crossing season boundaries. The first episode has no previous and the last Special (or last regular episode, if there are none) has no next.
 _Avoid_: Sibling episode, neighbour
 
 **Specials**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,23 @@
+# Segment Editor
+
+A web app for editing Jellyfin media segments (intro, outro, and similar ranges) on episodes, movies, and music tracks. The player page is where a single item's segments are edited.
+
+## Language
+
+### Episode navigation
+
+**Episode Switcher**:
+The header control on the player page that shows the current episode's title and lets the user pick any episode of the series.
+_Avoid_: Episode dropdown, episode picker
+
+**Series Order**:
+The sequence of a series' playable episodes: regular seasons ascending by season number, episodes ascending within each season. Specials are not part of Series Order.
+_Avoid_: Playback order, air order
+
+**Adjacent Episode**:
+The episode immediately before or after the current one in Series Order, crossing season boundaries. A Special's adjacent episodes are the neighbouring Specials only. The first and last episodes have no previous or next adjacent episode respectively.
+_Avoid_: Sibling episode, neighbour
+
+**Specials**:
+The season a series uses for out-of-sequence episodes. A season is Specials when Jellyfin numbers it 0 or its name contains "special", since some metadata providers number Specials differently.
+_Avoid_: Extras, season zero, special season

--- a/src/__tests__/adjacent-episodes.test.ts
+++ b/src/__tests__/adjacent-episodes.test.ts
@@ -91,21 +91,37 @@ describe('resolveAdjacentEpisodes', () => {
     expect(last.next).toBeNull()
   })
 
-  it('keeps Specials out of Series Order and in their own lane', async () => {
+  it('visits Specials after the last regular season, wherever Jellyfin lists them', async () => {
     const namedSpecials = season('extras', 7, 'Special Features')
     const { fetchers } = series([
       [SPECIALS, [episode('sp', 1), episode('sp', 2)]],
       [S1, [episode('s1', 1)]],
       [namedSpecials, [episode('extras', 1)]],
+      [S2, [episode('s2', 1)]],
     ])
 
-    const regular = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
-    expect(regular.previous).toBeNull()
-    expect(regular.next).toBeNull()
+    const first = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
+    expect(first.previous).toBeNull()
+    expect(first.next?.Id).toBe('s2-e1')
 
-    const special = await resolveAdjacentEpisodes(fetchers, episode('sp', 2))
-    expect(special.previous?.Id).toBe('sp-e1')
-    expect(special.next?.Id).toBe('extras-e1')
+    const lastRegular = await resolveAdjacentEpisodes(
+      fetchers,
+      episode('s2', 1),
+    )
+    expect(lastRegular.next?.Id).toBe('sp-e1')
+
+    const firstSpecial = await resolveAdjacentEpisodes(
+      fetchers,
+      episode('sp', 1),
+    )
+    expect(firstSpecial.previous?.Id).toBe('s2-e1')
+
+    const lastSpecial = await resolveAdjacentEpisodes(
+      fetchers,
+      episode('extras', 1),
+    )
+    expect(lastSpecial.previous?.Id).toBe('sp-e2')
+    expect(lastSpecial.next).toBeNull()
   })
 
   it('ignores Specials that Jellyfin merges into a season listing', async () => {
@@ -121,6 +137,12 @@ describe('resolveAdjacentEpisodes', () => {
 
     const last = await resolveAdjacentEpisodes(fetchers, episode('s1', 2))
     expect(last.next?.Id).toBe('s2-e1')
+
+    const endOfRegular = await resolveAdjacentEpisodes(
+      fetchers,
+      episode('s2', 1),
+    )
+    expect(endOfRegular.next?.Id).toBe('sp-e1')
   })
 
   it('resolves nothing when the episode is not in its season listing', async () => {

--- a/src/__tests__/adjacent-episodes.test.ts
+++ b/src/__tests__/adjacent-episodes.test.ts
@@ -108,6 +108,21 @@ describe('resolveAdjacentEpisodes', () => {
     expect(special.next?.Id).toBe('extras-e1')
   })
 
+  it('ignores Specials that Jellyfin merges into a season listing', async () => {
+    const mergedSpecial: BaseItemDto = { ...episode('sp', 1), Id: 'sp-e1' }
+    const { fetchers } = series([
+      [SPECIALS, [mergedSpecial]],
+      [S1, [mergedSpecial, episode('s1', 1), episode('s1', 2)]],
+      [S2, [mergedSpecial, episode('s2', 1)]],
+    ])
+
+    const first = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
+    expect(first.previous).toBeNull()
+
+    const last = await resolveAdjacentEpisodes(fetchers, episode('s1', 2))
+    expect(last.next?.Id).toBe('s2-e1')
+  })
+
   it('resolves nothing when the episode is not in its season listing', async () => {
     const { fetchers } = series([[S1, [episode('s1', 1)]]])
 

--- a/src/__tests__/adjacent-episodes.test.ts
+++ b/src/__tests__/adjacent-episodes.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { BaseItemDto } from '@/types/jellyfin'
+import { BaseItemKind } from '@/types/jellyfin'
+import { resolveAdjacentEpisodes } from '@/lib/adjacent-episodes'
+
+const season = (id: string, index: number, name?: string): BaseItemDto => ({
+  Id: id,
+  Type: BaseItemKind.Season,
+  IndexNumber: index,
+  Name: name ?? `Season ${index}`,
+})
+
+const episode = (seasonId: string, index: number): BaseItemDto => ({
+  Id: `${seasonId}-e${index}`,
+  Type: BaseItemKind.Episode,
+  SeriesId: 'series',
+  SeasonId: seasonId,
+  IndexNumber: index,
+})
+
+/** A series laid out as seasons (in Jellyfin order) with their playable episodes. */
+function series(layout: Array<[BaseItemDto, Array<BaseItemDto>]>) {
+  const episodesBySeason = new Map(
+    layout.map(([s, eps]) => [s.Id ?? '', eps] as const),
+  )
+  const fetchEpisodes = vi.fn(
+    async (_seriesId: string, seasonId: string) =>
+      episodesBySeason.get(seasonId) ?? [],
+  )
+  return {
+    fetchers: {
+      fetchSeasons: async () => layout.map(([s]) => s),
+      fetchEpisodes,
+    },
+    fetchEpisodes,
+  }
+}
+
+const S1 = season('s1', 1)
+const S2 = season('s2', 2)
+const S3 = season('s3', 3)
+const SPECIALS = season('sp', 0)
+
+describe('resolveAdjacentEpisodes', () => {
+  it('steps within a season without touching other seasons', async () => {
+    const { fetchers, fetchEpisodes } = series([
+      [S1, [episode('s1', 1), episode('s1', 2), episode('s1', 3)]],
+      [S2, [episode('s2', 1)]],
+    ])
+
+    const result = await resolveAdjacentEpisodes(fetchers, episode('s1', 2))
+
+    expect(result.previous?.Id).toBe('s1-e1')
+    expect(result.next?.Id).toBe('s1-e3')
+    expect(fetchEpisodes).toHaveBeenCalledTimes(1)
+  })
+
+  it('crosses season boundaries in both directions', async () => {
+    const { fetchers } = series([
+      [S1, [episode('s1', 1), episode('s1', 2)]],
+      [S2, [episode('s2', 1), episode('s2', 2)]],
+    ])
+
+    const lastOfS1 = await resolveAdjacentEpisodes(fetchers, episode('s1', 2))
+    expect(lastOfS1.next?.Id).toBe('s2-e1')
+
+    const firstOfS2 = await resolveAdjacentEpisodes(fetchers, episode('s2', 1))
+    expect(firstOfS2.previous?.Id).toBe('s1-e2')
+  })
+
+  it('skips seasons with no playable episodes', async () => {
+    const { fetchers } = series([
+      [S1, [episode('s1', 1)]],
+      [S2, []],
+      [S3, [episode('s3', 1)]],
+    ])
+
+    const result = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
+
+    expect(result.next?.Id).toBe('s3-e1')
+  })
+
+  it('has no adjacent episode at the ends of the series', async () => {
+    const { fetchers } = series([[S1, [episode('s1', 1), episode('s1', 2)]]])
+
+    const first = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
+    expect(first.previous).toBeNull()
+
+    const last = await resolveAdjacentEpisodes(fetchers, episode('s1', 2))
+    expect(last.next).toBeNull()
+  })
+
+  it('keeps Specials out of Series Order and in their own lane', async () => {
+    const namedSpecials = season('extras', 7, 'Special Features')
+    const { fetchers } = series([
+      [SPECIALS, [episode('sp', 1), episode('sp', 2)]],
+      [S1, [episode('s1', 1)]],
+      [namedSpecials, [episode('extras', 1)]],
+    ])
+
+    const regular = await resolveAdjacentEpisodes(fetchers, episode('s1', 1))
+    expect(regular.previous).toBeNull()
+    expect(regular.next).toBeNull()
+
+    const special = await resolveAdjacentEpisodes(fetchers, episode('sp', 2))
+    expect(special.previous?.Id).toBe('sp-e1')
+    expect(special.next?.Id).toBe('extras-e1')
+  })
+
+  it('resolves nothing when the episode is not in its season listing', async () => {
+    const { fetchers } = series([[S1, [episode('s1', 1)]]])
+
+    const result = await resolveAdjacentEpisodes(fetchers, episode('s1', 9))
+
+    expect(result).toEqual({ previous: null, next: null })
+  })
+})

--- a/src/__tests__/episode-navigation.test.tsx
+++ b/src/__tests__/episode-navigation.test.tsx
@@ -64,6 +64,14 @@ const previous: BaseItemDto = {
   Name: 'First',
 }
 
+const next: BaseItemDto = {
+  Id: 'ep-3',
+  Type: BaseItemKind.Episode,
+  ParentIndexNumber: 1,
+  IndexNumber: 3,
+  Name: 'Last',
+}
+
 /** The handler EpisodeNavigation registered for a hotkey, via the mocked useHotkey. */
 function registeredHandler(hotkey: string): () => void {
   const call = useHotkeyMock.mock.calls.findLast(
@@ -84,43 +92,51 @@ describe('EpisodeNavigation', () => {
     navigateMock.mockReset()
     preloadRouteMock.mockReset()
     useHotkeyMock.mockReset()
-    adjacentRef.current = { previous, next: null }
+    adjacentRef.current = { previous, next }
   })
 
   afterEach(() => {
     cleanup()
   })
 
-  it('enables the arrow that has a target and disables the one at the series boundary', () => {
+  it('shows only a next arrow, naming its target and shortcut', () => {
     render(<EpisodeNavigation currentEpisode={current} />)
 
-    const prevButton = screen.getByRole('button', {
-      name: 'Previous episode: S1E1 First',
+    const nextButton = screen.getByRole('button', {
+      name: 'Next episode: S1E3 Last',
     })
-    const nextButton = screen.getByRole('button', { name: 'Next episode' })
 
-    expect(prevButton.hasAttribute('disabled')).toBe(false)
-    expect(nextButton.hasAttribute('disabled')).toBe(true)
-    expect(prevButton.getAttribute('title')).toBe(
-      `S1E1 First (${EPISODE_HOTKEYS.previousEpisode})`,
+    expect(nextButton.hasAttribute('disabled')).toBe(false)
+    expect(nextButton.getAttribute('title')).toBe(
+      `S1E3 Last (${EPISODE_HOTKEYS.nextEpisode})`,
     )
+    expect(screen.queryByRole('button', { name: /previous/i })).toBeNull()
   })
 
-  it('navigates to the target on click and preloads it on hover', () => {
+  it('disables the next arrow at the end of the series', () => {
+    adjacentRef.current = { previous, next: null }
     render(<EpisodeNavigation currentEpisode={current} />)
 
-    const prevButton = screen.getByRole('button', {
-      name: 'Previous episode: S1E1 First',
-    })
-
-    fireEvent.pointerEnter(prevButton)
-    expect(preloadRouteMock).toHaveBeenCalledWith(expectedRoute('ep-1'))
-
-    fireEvent.click(prevButton)
-    expect(navigateMock).toHaveBeenCalledWith(expectedRoute('ep-1'))
+    const nextButton = screen.getByRole('button', { name: 'Next episode' })
+    expect(nextButton.hasAttribute('disabled')).toBe(true)
   })
 
-  it('binds the hotkeys and makes them no-ops without a target', () => {
+  it('navigates to the next episode on click and preloads it on hover', () => {
+    render(<EpisodeNavigation currentEpisode={current} />)
+
+    const nextButton = screen.getByRole('button', {
+      name: 'Next episode: S1E3 Last',
+    })
+
+    fireEvent.pointerEnter(nextButton)
+    expect(preloadRouteMock).toHaveBeenCalledWith(expectedRoute('ep-3'))
+
+    fireEvent.click(nextButton)
+    expect(navigateMock).toHaveBeenCalledWith(expectedRoute('ep-3'))
+  })
+
+  it('binds both hotkeys and makes them no-ops without a target', () => {
+    adjacentRef.current = { previous, next: null }
     render(<EpisodeNavigation currentEpisode={current} />)
 
     registeredHandler(EPISODE_HOTKEYS.nextEpisode)()

--- a/src/__tests__/episode-navigation.test.tsx
+++ b/src/__tests__/episode-navigation.test.tsx
@@ -17,7 +17,7 @@ const { navigateMock, preloadRouteMock, useHotkeyMock, adjacentRef } =
   vi.hoisted(() => ({
     navigateMock: vi.fn(),
     preloadRouteMock: vi.fn(),
-    useHotkeyMock: vi.fn(),
+    useHotkeyMock: vi.fn<(hotkey: string, callback: () => void) => void>(),
     adjacentRef: { current: null as AdjacentEpisodes | null },
   }))
 
@@ -70,7 +70,7 @@ function registeredHandler(hotkey: string): () => void {
     ([registered]) => registered === hotkey,
   )
   if (!call) throw new Error(`No handler registered for ${hotkey}`)
-  return call[1] as () => void
+  return call[1]
 }
 
 const expectedRoute = (itemId: string) => ({

--- a/src/__tests__/episode-navigation.test.tsx
+++ b/src/__tests__/episode-navigation.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BaseItemDto } from '@/types/jellyfin'
+import { BaseItemKind } from '@/types/jellyfin'
+import type { AdjacentEpisodes } from '@/lib/adjacent-episodes'
+import { EPISODE_HOTKEYS } from '@/lib/player-shortcuts'
+import EpisodeNavigation from '@/components/header/EpisodeNavigation'
+import { resolveTranslation } from './helpers/i18n-mock'
+import type { TranslationArg } from './helpers/i18n-mock'
+
+const { navigateMock, preloadRouteMock, useHotkeyMock, adjacentRef } =
+  vi.hoisted(() => ({
+    navigateMock: vi.fn(),
+    preloadRouteMock: vi.fn(),
+    useHotkeyMock: vi.fn(),
+    adjacentRef: { current: null as AdjacentEpisodes | null },
+  }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: TranslationArg) =>
+      resolveTranslation(key, fallback),
+  }),
+}))
+
+vi.mock('@tanstack/react-hotkeys', () => ({
+  formatForDisplay: (shortcut: string) => shortcut,
+  useHotkey: useHotkeyMock,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+  useRouter: () => ({ preloadRoute: preloadRouteMock }),
+}))
+
+vi.mock('@/services/items/queries', () => ({
+  useAdjacentEpisodes: () => ({ data: adjacentRef.current }),
+}))
+
+vi.mock('@/components/header/EpisodeSwitcher', () => ({
+  default: () => <div data-testid="episode-switcher" />,
+}))
+
+const current: BaseItemDto = {
+  Id: 'ep-2',
+  Type: BaseItemKind.Episode,
+  SeriesId: 'series',
+  SeasonId: 's1',
+  ParentIndexNumber: 1,
+  IndexNumber: 2,
+  Name: 'Middle',
+}
+
+const previous: BaseItemDto = {
+  Id: 'ep-1',
+  Type: BaseItemKind.Episode,
+  ParentIndexNumber: 1,
+  IndexNumber: 1,
+  Name: 'First',
+}
+
+/** The handler EpisodeNavigation registered for a hotkey, via the mocked useHotkey. */
+function registeredHandler(hotkey: string): () => void {
+  const call = useHotkeyMock.mock.calls.findLast(
+    ([registered]) => registered === hotkey,
+  )
+  if (!call) throw new Error(`No handler registered for ${hotkey}`)
+  return call[1] as () => void
+}
+
+const expectedRoute = (itemId: string) => ({
+  to: '/player/$itemId',
+  params: { itemId },
+  search: { fetchSegments: 'true' },
+})
+
+describe('EpisodeNavigation', () => {
+  beforeEach(() => {
+    navigateMock.mockReset()
+    preloadRouteMock.mockReset()
+    useHotkeyMock.mockReset()
+    adjacentRef.current = { previous, next: null }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('enables the arrow that has a target and disables the one at the series boundary', () => {
+    render(<EpisodeNavigation currentEpisode={current} />)
+
+    const prevButton = screen.getByRole('button', {
+      name: 'Previous episode: S1E1 First',
+    })
+    const nextButton = screen.getByRole('button', { name: 'Next episode' })
+
+    expect(prevButton.hasAttribute('disabled')).toBe(false)
+    expect(nextButton.hasAttribute('disabled')).toBe(true)
+    expect(prevButton.getAttribute('title')).toBe(
+      `S1E1 First (${EPISODE_HOTKEYS.previousEpisode})`,
+    )
+  })
+
+  it('navigates to the target on click and preloads it on hover', () => {
+    render(<EpisodeNavigation currentEpisode={current} />)
+
+    const prevButton = screen.getByRole('button', {
+      name: 'Previous episode: S1E1 First',
+    })
+
+    fireEvent.pointerEnter(prevButton)
+    expect(preloadRouteMock).toHaveBeenCalledWith(expectedRoute('ep-1'))
+
+    fireEvent.click(prevButton)
+    expect(navigateMock).toHaveBeenCalledWith(expectedRoute('ep-1'))
+  })
+
+  it('binds the hotkeys and makes them no-ops without a target', () => {
+    render(<EpisodeNavigation currentEpisode={current} />)
+
+    registeredHandler(EPISODE_HOTKEYS.nextEpisode)()
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    registeredHandler(EPISODE_HOTKEYS.previousEpisode)()
+    expect(navigateMock).toHaveBeenCalledWith(expectedRoute('ep-1'))
+  })
+
+  it('renders nothing for items that are not episodes', () => {
+    const { container } = render(
+      <EpisodeNavigation
+        currentEpisode={{ ...current, Type: BaseItemKind.Movie }}
+      />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/__tests__/header-title.test.tsx
+++ b/src/__tests__/header-title.test.tsx
@@ -84,7 +84,7 @@ vi.mock('@/services/video/api', () => ({
   getBestImageUrl: () => null,
 }))
 
-vi.mock('@/components/header/EpisodeSwitcher', () => ({
+vi.mock('@/components/header/EpisodeNavigation', () => ({
   default: ({ currentEpisode }: { currentEpisode: BaseItemDto }) => (
     <div data-testid="episode-switcher">{currentEpisode.Name}</div>
   ),

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,7 +33,8 @@ import type { BaseItemDto } from '@/types/jellyfin'
 // React.lazy and hover/focus preloading require dynamic imports to preserve code splitting.
 const loadCommandPalette = () => import('@/components/header/CommandPalette')
 const rootRouteApi = getRouteApi('__root__')
-const loadEpisodeSwitcher = () => import('@/components/header/EpisodeSwitcher')
+const loadEpisodeNavigation = () =>
+  import('@/components/header/EpisodeNavigation')
 const loadSettingsDialog = () => import('@/components/settings')
 
 const ignorePreloadError = () => undefined
@@ -48,7 +49,7 @@ const preloadSettingsDialog = () => {
 
 const CommandPalette = lazy(loadCommandPalette)
 
-const EpisodeSwitcher = lazy(loadEpisodeSwitcher)
+const EpisodeNavigation = lazy(loadEpisodeNavigation)
 
 interface CollectionSelectorProps {
   collections: Array<{ ItemId?: string | null; Name?: string | null }>
@@ -176,7 +177,7 @@ function DetailHeaderContent({
               </span>
             }
           >
-            <EpisodeSwitcher
+            <EpisodeNavigation
               currentEpisode={currentItem}
               className="flex-1 min-w-0"
             />

--- a/src/components/header/EpisodeNavigation.tsx
+++ b/src/components/header/EpisodeNavigation.tsx
@@ -1,0 +1,112 @@
+import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys'
+import { useTranslation } from 'react-i18next'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+import type { BaseItemDto } from '@/types/jellyfin'
+import { useAdjacentEpisodes } from '@/services/items/queries'
+import { Button } from '@/components/ui/button'
+import EpisodeSwitcher from '@/components/header/EpisodeSwitcher'
+import { formatEpisodeLabel } from '@/lib/header-utils'
+import { EPISODE_HOTKEYS } from '@/lib/player-shortcuts'
+import { cn } from '@/lib/utils'
+import { useEpisodeRouteNavigation } from './use-episode-route-navigation'
+
+const PREVIOUS_HOTKEY_DISPLAY = formatForDisplay(
+  EPISODE_HOTKEYS.previousEpisode,
+)
+const NEXT_HOTKEY_DISPLAY = formatForDisplay(EPISODE_HOTKEYS.nextEpisode)
+
+interface EpisodeArrowProps {
+  /** The Adjacent Episode this arrow leads to; null disables the arrow at a series boundary. */
+  target: BaseItemDto | null
+  label: string
+  hotkeyDisplay: string
+  icon: typeof ChevronLeft
+  onSelect: (episodeId: string) => void
+  onIntent: (episodeId: string) => void
+}
+
+function EpisodeArrow({
+  target,
+  label,
+  hotkeyDisplay,
+  icon: Icon,
+  onSelect,
+  onIntent,
+}: EpisodeArrowProps) {
+  const targetId = target?.Id
+  const targetLabel = formatEpisodeLabel(target)
+  const intent = () => {
+    if (targetId) onIntent(targetId)
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      disabled={!targetId}
+      onClick={() => {
+        if (targetId) onSelect(targetId)
+      }}
+      onPointerEnter={intent}
+      onFocus={intent}
+      className="rounded-lg text-muted-foreground hover:text-foreground disabled:opacity-30"
+      aria-label={targetLabel ? `${label}: ${targetLabel}` : label}
+      title={`${targetLabel ?? label} (${hotkeyDisplay})`}
+    >
+      <Icon className="size-6" aria-hidden />
+    </Button>
+  )
+}
+
+interface EpisodeNavigationProps {
+  currentEpisode: BaseItemDto
+  className?: string
+}
+
+/**
+ * Header control for the player page: previous and next arrows flanking the
+ * Episode Switcher, plus the Shift+P / Shift+N hotkeys that do the same thing.
+ * Arrows stay visible but disabled at the first and last episode of the series.
+ */
+export default function EpisodeNavigation({
+  currentEpisode,
+  className,
+}: EpisodeNavigationProps) {
+  const { t } = useTranslation()
+  const { data: adjacent } = useAdjacentEpisodes(currentEpisode)
+  const { goToEpisode, preloadEpisode } = useEpisodeRouteNavigation()
+  const previous = adjacent?.previous ?? null
+  const next = adjacent?.next ?? null
+
+  useHotkey(EPISODE_HOTKEYS.previousEpisode, () => {
+    if (previous?.Id) goToEpisode(previous.Id)
+  })
+  useHotkey(EPISODE_HOTKEYS.nextEpisode, () => {
+    if (next?.Id) goToEpisode(next.Id)
+  })
+
+  if (!currentEpisode.SeriesId || currentEpisode.Type !== 'Episode') return null
+
+  return (
+    <div className={cn('flex items-center gap-1 min-w-0', className)}>
+      <EpisodeArrow
+        target={previous}
+        label={t('player.previousEpisode', 'Previous episode')}
+        hotkeyDisplay={PREVIOUS_HOTKEY_DISPLAY}
+        icon={ChevronLeft}
+        onSelect={goToEpisode}
+        onIntent={preloadEpisode}
+      />
+      <EpisodeSwitcher currentEpisode={currentEpisode} className="min-w-0" />
+      <EpisodeArrow
+        target={next}
+        label={t('player.nextEpisode', 'Next episode')}
+        hotkeyDisplay={NEXT_HOTKEY_DISPLAY}
+        icon={ChevronRight}
+        onSelect={goToEpisode}
+        onIntent={preloadEpisode}
+      />
+    </div>
+  )
+}

--- a/src/components/header/EpisodeNavigation.tsx
+++ b/src/components/header/EpisodeNavigation.tsx
@@ -1,6 +1,6 @@
 import { formatForDisplay, useHotkey } from '@tanstack/react-hotkeys'
 import { useTranslation } from 'react-i18next'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 
 import type { BaseItemDto } from '@/types/jellyfin'
 import { useAdjacentEpisodes } from '@/services/items/queries'
@@ -11,29 +11,22 @@ import { EPISODE_HOTKEYS } from '@/lib/player-shortcuts'
 import { cn } from '@/lib/utils'
 import { useEpisodeRouteNavigation } from './use-episode-route-navigation'
 
-const PREVIOUS_HOTKEY_DISPLAY = formatForDisplay(
-  EPISODE_HOTKEYS.previousEpisode,
-)
 const NEXT_HOTKEY_DISPLAY = formatForDisplay(EPISODE_HOTKEYS.nextEpisode)
 
-interface EpisodeArrowProps {
-  /** The Adjacent Episode this arrow leads to; null disables the arrow at a series boundary. */
+interface NextEpisodeArrowProps {
+  /** The next Adjacent Episode; null disables the arrow at the end of the series. */
   target: BaseItemDto | null
   label: string
-  hotkeyDisplay: string
-  icon: typeof ChevronLeft
   onSelect: (episodeId: string) => void
   onIntent: (episodeId: string) => void
 }
 
-function EpisodeArrow({
+function NextEpisodeArrow({
   target,
   label,
-  hotkeyDisplay,
-  icon: Icon,
   onSelect,
   onIntent,
-}: EpisodeArrowProps) {
+}: NextEpisodeArrowProps) {
   const targetId = target?.Id
   const targetLabel = formatEpisodeLabel(target)
   const intent = () => {
@@ -52,9 +45,9 @@ function EpisodeArrow({
       onFocus={intent}
       className="rounded-lg text-muted-foreground hover:text-foreground disabled:opacity-30"
       aria-label={targetLabel ? `${label}: ${targetLabel}` : label}
-      title={`${targetLabel ?? label} (${hotkeyDisplay})`}
+      title={`${targetLabel ?? label} (${NEXT_HOTKEY_DISPLAY})`}
     >
-      <Icon className="size-6" aria-hidden />
+      <ChevronRight className="size-6" aria-hidden />
     </Button>
   )
 }
@@ -65,9 +58,11 @@ interface EpisodeNavigationProps {
 }
 
 /**
- * Header control for the player page: previous and next arrows flanking the
- * Episode Switcher, plus the Shift+P / Shift+N hotkeys that do the same thing.
- * Arrows stay visible but disabled at the first and last episode of the series.
+ * Header control for the player page: the Episode Switcher with a next arrow
+ * after it, plus Shift+N for next and Shift+P for previous. Only next gets an
+ * arrow, so it cannot be confused with the back button; a sweep runs forward
+ * and the dropdown covers the rare step back. The arrow stays visible but
+ * disabled at the last episode of the series.
  */
 export default function EpisodeNavigation({
   currentEpisode,
@@ -90,20 +85,10 @@ export default function EpisodeNavigation({
 
   return (
     <div className={cn('flex items-center gap-1 min-w-0', className)}>
-      <EpisodeArrow
-        target={previous}
-        label={t('player.previousEpisode', 'Previous episode')}
-        hotkeyDisplay={PREVIOUS_HOTKEY_DISPLAY}
-        icon={ChevronLeft}
-        onSelect={goToEpisode}
-        onIntent={preloadEpisode}
-      />
       <EpisodeSwitcher currentEpisode={currentEpisode} className="min-w-0" />
-      <EpisodeArrow
+      <NextEpisodeArrow
         target={next}
         label={t('player.nextEpisode', 'Next episode')}
-        hotkeyDisplay={NEXT_HOTKEY_DISPLAY}
-        icon={ChevronRight}
         onSelect={goToEpisode}
         onIntent={preloadEpisode}
       />

--- a/src/components/header/EpisodeSwitcher.tsx
+++ b/src/components/header/EpisodeSwitcher.tsx
@@ -1,5 +1,4 @@
-import { useRef, useState } from 'react'
-import { useNavigate, useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AlertCircle, Check, ChevronDown, Play } from 'lucide-react'
 
@@ -18,6 +17,8 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { staggerDelay } from '@/lib/animation-utils'
 import { formatEpisodeLabel } from '@/lib/header-utils'
+import { isSpecialSeason } from '@/lib/series-utils'
+import { useEpisodeRouteNavigation } from './use-episode-route-navigation'
 
 interface EpisodeSwitcherProps {
   currentEpisode: BaseItemDto
@@ -150,12 +151,10 @@ const SeasonButton = function SeasonButtonComponent({
     if (season.Id) onSeasonSelect(season.Id)
   }
 
-  const label =
-    season.IndexNumber === 0 ? 'SP' : `S${season.IndexNumber ?? '?'}`
-  const fullLabel =
-    season.IndexNumber === 0
-      ? 'Specials'
-      : `Season ${season.IndexNumber ?? '?'}`
+  const label = isSpecialSeason(season) ? 'SP' : `S${season.IndexNumber ?? '?'}`
+  const fullLabel = isSpecialSeason(season)
+    ? 'Specials'
+    : `Season ${season.IndexNumber ?? '?'}`
 
   return (
     <button
@@ -346,13 +345,8 @@ export default function EpisodeSwitcher({
   className,
 }: EpisodeSwitcherProps) {
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const router = useRouter()
+  const { goToEpisode, preloadEpisode } = useEpisodeRouteNavigation()
   const [open, setOpen] = useState(false)
-  const prefetchedEpisodeIdsRef = useRef<Set<string> | null>(null)
-  if (prefetchedEpisodeIdsRef.current === null) {
-    prefetchedEpisodeIdsRef.current = new Set<string>()
-  }
   const [episodeListElement, setEpisodeListElement] =
     useState<HTMLDivElement | null>(null)
 
@@ -374,27 +368,7 @@ export default function EpisodeSwitcher({
 
   const handleEpisodeSelect = (episodeId: string) => {
     setOpen(false)
-    void navigate({
-      to: '/player/$itemId',
-      params: { itemId: episodeId },
-      search: { fetchSegments: 'true' },
-    })
-  }
-
-  const prefetchEpisodeRoute = (episodeId: string) => {
-    const prefetchedEpisodeIds = prefetchedEpisodeIdsRef.current
-    if (prefetchedEpisodeIds === null) return
-
-    if (!episodeId || prefetchedEpisodeIds.has(episodeId)) {
-      return
-    }
-
-    prefetchedEpisodeIds.add(episodeId)
-    void router.preloadRoute({
-      to: '/player/$itemId',
-      params: { itemId: episodeId },
-      search: { fetchSegments: 'true' },
-    })
+    goToEpisode(episodeId)
   }
 
   if (!seriesId || currentEpisode.Type !== 'Episode') return null
@@ -452,7 +426,7 @@ export default function EpisodeSwitcher({
             isLoading={isLoading}
             isError={isError}
             onSelect={handleEpisodeSelect}
-            onIntent={prefetchEpisodeRoute}
+            onIntent={preloadEpisode}
             scrollElement={episodeListElement}
           />
         </div>

--- a/src/components/header/use-episode-route-navigation.ts
+++ b/src/components/header/use-episode-route-navigation.ts
@@ -1,0 +1,38 @@
+import { useRef } from 'react'
+import { useNavigate, useRouter } from '@tanstack/react-router'
+
+const episodeRoute = (episodeId: string) =>
+  ({
+    to: '/player/$itemId',
+    params: { itemId: episodeId },
+    search: { fetchSegments: 'true' },
+  }) as const
+
+/**
+ * Navigation to another episode's player page, shared by the Episode Switcher
+ * and the previous/next arrows so both land on the same route with segments
+ * fetched. `preloadEpisode` warms the route once per episode on hover or focus.
+ */
+export function useEpisodeRouteNavigation() {
+  const navigate = useNavigate()
+  const router = useRouter()
+  const preloadedEpisodeIdsRef = useRef<Set<string> | null>(null)
+  if (preloadedEpisodeIdsRef.current === null) {
+    preloadedEpisodeIdsRef.current = new Set<string>()
+  }
+
+  const goToEpisode = (episodeId: string) => {
+    void navigate(episodeRoute(episodeId))
+  }
+
+  const preloadEpisode = (episodeId: string) => {
+    const preloadedEpisodeIds = preloadedEpisodeIdsRef.current
+    if (preloadedEpisodeIds === null || preloadedEpisodeIds.has(episodeId)) {
+      return
+    }
+    preloadedEpisodeIds.add(episodeId)
+    void router.preloadRoute(episodeRoute(episodeId))
+  }
+
+  return { goToEpisode, preloadEpisode }
+}

--- a/src/components/header/use-episode-route-navigation.ts
+++ b/src/components/header/use-episode-route-navigation.ts
@@ -1,12 +1,6 @@
 import { useRef } from 'react'
 import { useNavigate, useRouter } from '@tanstack/react-router'
-
-const episodeRoute = (episodeId: string) =>
-  ({
-    to: '/player/$itemId',
-    params: { itemId: episodeId },
-    search: { fetchSegments: 'true' },
-  }) as const
+import { getPlayerNavigationRoute } from '@/lib/navigation-utils'
 
 /**
  * Navigation to another episode's player page, shared by the Episode Switcher
@@ -22,7 +16,7 @@ export function useEpisodeRouteNavigation() {
   }
 
   const goToEpisode = (episodeId: string) => {
-    void navigate(episodeRoute(episodeId))
+    void navigate(getPlayerNavigationRoute(episodeId))
   }
 
   const preloadEpisode = (episodeId: string) => {
@@ -31,7 +25,7 @@ export function useEpisodeRouteNavigation() {
       return
     }
     preloadedEpisodeIds.add(episodeId)
-    void router.preloadRoute(episodeRoute(episodeId))
+    void router.preloadRoute(getPlayerNavigationRoute(episodeId))
   }
 
   return { goToEpisode, preloadEpisode }

--- a/src/components/views/SeriesView.tsx
+++ b/src/components/views/SeriesView.tsx
@@ -13,6 +13,7 @@ import { LoadingState } from '@/components/ui/async-state'
 import { EmptyState } from '@/components/ui/empty-state'
 import { ErrorState } from '@/components/ui/error-state'
 import { cn } from '@/lib/utils'
+import { isSpecialSeason } from '@/lib/series-utils'
 import { ticksToSeconds } from '@/lib/time-utils'
 import { staggerDelay, STAGGER_NORMAL } from '@/lib/animation-utils'
 
@@ -28,9 +29,6 @@ interface SeasonTabsProps {
   selectedSeasonId: string | null
   onSeasonSelect: (seasonId: string) => void
 }
-
-const isSpecialSeason = (s: BaseItemDto) =>
-  s.IndexNumber === 0 || (s.Name || '').toLowerCase().includes('special')
 
 const SeasonTabs = function SeasonTabsComponent({
   seasons,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -253,7 +253,6 @@
     "fitScreen": "An Bildschirm anpassen",
     "retry": "Erneut versuchen",
     "selectEpisode": "Episode auswählen",
-    "previousEpisode": "Vorherige Episode",
     "nextEpisode": "Nächste Episode",
     "controls": "Steuerung des Videoplayers",
     "recovering": "Wiedergabe wird wiederhergestellt",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -253,6 +253,8 @@
     "fitScreen": "An Bildschirm anpassen",
     "retry": "Erneut versuchen",
     "selectEpisode": "Episode auswählen",
+    "previousEpisode": "Vorherige Episode",
+    "nextEpisode": "Nächste Episode",
     "controls": "Steuerung des Videoplayers",
     "recovering": "Wiedergabe wird wiederhergestellt",
     "directPlay": "Direktwiedergabe",
@@ -335,6 +337,8 @@
     "saveAll": "Alle speichern",
     "prevSegment": "Vorheriges Segment",
     "nextSegment": "Nächstes Segment",
+    "prevEpisode": "Vorherige Episode",
+    "nextEpisode": "Nächste Episode",
     "increaseSpeed": "Schneller",
     "decreaseSpeed": "Langsamer",
     "stepFrameBackForward": "Einzelbild zurück / vorwärts"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -253,6 +253,8 @@
     "fitScreen": "Fit to screen",
     "retry": "Retry",
     "selectEpisode": "Select episode",
+    "previousEpisode": "Previous episode",
+    "nextEpisode": "Next episode",
     "controls": "Video player controls",
     "recovering": "Recovering playback",
     "directPlay": "Direct play",
@@ -335,6 +337,8 @@
     "saveAll": "Save all",
     "prevSegment": "Previous segment",
     "nextSegment": "Next segment",
+    "prevEpisode": "Previous episode",
+    "nextEpisode": "Next episode",
     "increaseSpeed": "Increase speed",
     "decreaseSpeed": "Decrease speed",
     "stepFrameBackForward": "Step frame back / forward"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -253,7 +253,6 @@
     "fitScreen": "Fit to screen",
     "retry": "Retry",
     "selectEpisode": "Select episode",
-    "previousEpisode": "Previous episode",
     "nextEpisode": "Next episode",
     "controls": "Video player controls",
     "recovering": "Recovering playback",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -192,6 +192,8 @@
     "fitScreen": "Ajuster à l'écran",
     "retry": "Réessayer",
     "selectEpisode": "Sélectionner un épisode",
+    "previousEpisode": "Épisode précédent",
+    "nextEpisode": "Épisode suivant",
     "directPlay": "Lecture directe",
     "hlsFallback": "Lecture transcodée",
     "direct": "Direct",
@@ -268,6 +270,8 @@
     "saveAll": "Tout enregistrer",
     "prevSegment": "Segment précédent",
     "nextSegment": "Segment suivant",
+    "prevEpisode": "Épisode précédent",
+    "nextEpisode": "Épisode suivant",
     "increaseSpeed": "Accélérer",
     "decreaseSpeed": "Ralentir",
     "stepFrameBackForward": "Image précédente / suivante"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -192,7 +192,6 @@
     "fitScreen": "Ajuster à l'écran",
     "retry": "Réessayer",
     "selectEpisode": "Sélectionner un épisode",
-    "previousEpisode": "Épisode précédent",
     "nextEpisode": "Épisode suivant",
     "directPlay": "Lecture directe",
     "hlsFallback": "Lecture transcodée",

--- a/src/lib/adjacent-episodes.ts
+++ b/src/lib/adjacent-episodes.ts
@@ -20,18 +20,17 @@ const NO_ADJACENT: AdjacentEpisodes = { previous: null, next: null }
 /**
  * Jellyfin merges Specials that air before or after a season into that
  * season's listing when the user's DisplaySpecialsWithinSeasons setting is on
- * (the default). Series Order excludes Specials, so keep the season's own
- * episodes only.
+ * (the default). Series Order visits Specials once, at the end, so keep the
+ * season's own episodes only.
  */
 const ownEpisodes = (episodes: Array<BaseItemDto>, seasonId: string) =>
   episodes.filter((item) => item.SeasonId === seasonId)
 
 /**
  * Resolves the Adjacent Episodes of `episode` in Series Order (see CONTEXT.md):
- * seasons in the order Jellyfin returns them, episodes in order within each
- * season, crossing season boundaries and skipping seasons with no playable
- * episodes. Specials form their own lane, so a regular episode never steps
- * into Specials and a Special never steps out.
+ * regular seasons in the order Jellyfin returns them, then Specials, with
+ * episodes in order within each season. Stepping crosses season boundaries
+ * and skips seasons with no playable episodes.
  */
 export async function resolveAdjacentEpisodes(
   fetchers: SeriesFetchers,
@@ -44,11 +43,12 @@ export async function resolveAdjacentEpisodes(
   const currentSeason = seasons.find((season) => season.Id === seasonId)
   if (!currentSeason) return NO_ADJACENT
 
-  const inSpecials = isSpecialSeason(currentSeason)
-  const lane = seasons.filter(
-    (season) => isSpecialSeason(season) === inSpecials,
-  )
-  const seasonIndex = lane.indexOf(currentSeason)
+  // Same order the series page shows its season tabs in.
+  const ordered = [
+    ...seasons.filter((season) => !isSpecialSeason(season)),
+    ...seasons.filter(isSpecialSeason),
+  ]
+  const seasonIndex = ordered.indexOf(currentSeason)
 
   const episodes = ownEpisodes(
     await fetchers.fetchEpisodes(seriesId, seasonId),
@@ -79,10 +79,10 @@ export async function resolveAdjacentEpisodes(
   const [previous, next] = await Promise.all([
     episodeIndex > 0
       ? episodes[episodeIndex - 1]
-      : findAcrossSeasons(lane.slice(0, seasonIndex).reverse(), 'last'),
+      : findAcrossSeasons(ordered.slice(0, seasonIndex).reverse(), 'last'),
     episodeIndex < episodes.length - 1
       ? episodes[episodeIndex + 1]
-      : findAcrossSeasons(lane.slice(seasonIndex + 1), 'first'),
+      : findAcrossSeasons(ordered.slice(seasonIndex + 1), 'first'),
   ])
 
   return { previous, next }

--- a/src/lib/adjacent-episodes.ts
+++ b/src/lib/adjacent-episodes.ts
@@ -18,6 +18,15 @@ export interface SeriesFetchers {
 const NO_ADJACENT: AdjacentEpisodes = { previous: null, next: null }
 
 /**
+ * Jellyfin merges Specials that air before or after a season into that
+ * season's listing when the user's DisplaySpecialsWithinSeasons setting is on
+ * (the default). Series Order excludes Specials, so keep the season's own
+ * episodes only.
+ */
+const ownEpisodes = (episodes: Array<BaseItemDto>, seasonId: string) =>
+  episodes.filter((item) => item.SeasonId === seasonId)
+
+/**
  * Resolves the Adjacent Episodes of `episode` in Series Order (see CONTEXT.md):
  * seasons in the order Jellyfin returns them, episodes in order within each
  * season, crossing season boundaries and skipping seasons with no playable
@@ -41,7 +50,10 @@ export async function resolveAdjacentEpisodes(
   )
   const seasonIndex = lane.indexOf(currentSeason)
 
-  const episodes = await fetchers.fetchEpisodes(seriesId, seasonId)
+  const episodes = ownEpisodes(
+    await fetchers.fetchEpisodes(seriesId, seasonId),
+    seasonId,
+  )
   const episodeIndex = episodes.findIndex((item) => item.Id === episodeId)
   if (episodeIndex === -1) return NO_ADJACENT
 
@@ -52,7 +64,10 @@ export async function resolveAdjacentEpisodes(
   ): Promise<BaseItemDto | null> => {
     for (const season of candidates) {
       if (!season.Id) continue
-      const seasonEpisodes = await fetchers.fetchEpisodes(seriesId, season.Id)
+      const seasonEpisodes = ownEpisodes(
+        await fetchers.fetchEpisodes(seriesId, season.Id),
+        season.Id,
+      )
       if (seasonEpisodes.length === 0) continue
       return pick === 'first'
         ? seasonEpisodes[0]

--- a/src/lib/adjacent-episodes.ts
+++ b/src/lib/adjacent-episodes.ts
@@ -1,0 +1,74 @@
+import type { BaseItemDto } from '@/types/jellyfin'
+import { isSpecialSeason } from '@/lib/series-utils'
+
+export interface AdjacentEpisodes {
+  previous: BaseItemDto | null
+  next: BaseItemDto | null
+}
+
+/** Data access the resolver needs; callers route these through the query cache. */
+export interface SeriesFetchers {
+  fetchSeasons: (seriesId: string) => Promise<Array<BaseItemDto>>
+  fetchEpisodes: (
+    seriesId: string,
+    seasonId: string,
+  ) => Promise<Array<BaseItemDto>>
+}
+
+const NO_ADJACENT: AdjacentEpisodes = { previous: null, next: null }
+
+/**
+ * Resolves the Adjacent Episodes of `episode` in Series Order (see CONTEXT.md):
+ * seasons in the order Jellyfin returns them, episodes in order within each
+ * season, crossing season boundaries and skipping seasons with no playable
+ * episodes. Specials form their own lane, so a regular episode never steps
+ * into Specials and a Special never steps out.
+ */
+export async function resolveAdjacentEpisodes(
+  fetchers: SeriesFetchers,
+  episode: BaseItemDto,
+): Promise<AdjacentEpisodes> {
+  const { Id: episodeId, SeriesId: seriesId, SeasonId: seasonId } = episode
+  if (!episodeId || !seriesId || !seasonId) return NO_ADJACENT
+
+  const seasons = await fetchers.fetchSeasons(seriesId)
+  const currentSeason = seasons.find((season) => season.Id === seasonId)
+  if (!currentSeason) return NO_ADJACENT
+
+  const inSpecials = isSpecialSeason(currentSeason)
+  const lane = seasons.filter(
+    (season) => isSpecialSeason(season) === inSpecials,
+  )
+  const seasonIndex = lane.indexOf(currentSeason)
+
+  const episodes = await fetchers.fetchEpisodes(seriesId, seasonId)
+  const episodeIndex = episodes.findIndex((item) => item.Id === episodeId)
+  if (episodeIndex === -1) return NO_ADJACENT
+
+  /** Walks `candidates` in order and returns the first or last episode of the first season that has any. */
+  const findAcrossSeasons = async (
+    candidates: Array<BaseItemDto>,
+    pick: 'first' | 'last',
+  ): Promise<BaseItemDto | null> => {
+    for (const season of candidates) {
+      if (!season.Id) continue
+      const seasonEpisodes = await fetchers.fetchEpisodes(seriesId, season.Id)
+      if (seasonEpisodes.length === 0) continue
+      return pick === 'first'
+        ? seasonEpisodes[0]
+        : seasonEpisodes[seasonEpisodes.length - 1]
+    }
+    return null
+  }
+
+  const [previous, next] = await Promise.all([
+    episodeIndex > 0
+      ? episodes[episodeIndex - 1]
+      : findAcrossSeasons(lane.slice(0, seasonIndex).reverse(), 'last'),
+    episodeIndex < episodes.length - 1
+      ? episodes[episodeIndex + 1]
+      : findAcrossSeasons(lane.slice(seasonIndex + 1), 'first'),
+  ])
+
+  return { previous, next }
+}

--- a/src/lib/navigation-utils.ts
+++ b/src/lib/navigation-utils.ts
@@ -69,7 +69,8 @@ function isPlayerItemKind(
   return PLAYER_ITEM_KINDS.some((kind) => kind === itemType)
 }
 
-function getPlayerNavigationRoute(itemId: string): NavigationRoute {
+/** Player page for an item, with segment fetching enabled. */
+export function getPlayerNavigationRoute(itemId: string): NavigationRoute {
   return {
     to: '/player/$itemId',
     params: { itemId },

--- a/src/lib/player-shortcuts.ts
+++ b/src/lib/player-shortcuts.ts
@@ -20,9 +20,15 @@ export const PLAYER_HOTKEYS = {
   decreaseSpeed: 'Alt+,',
 } as const
 
+/** Hotkeys for stepping to the Adjacent Episode, registered by EpisodeNavigation in the header. */
+export const EPISODE_HOTKEYS = {
+  previousEpisode: 'Shift+P',
+  nextEpisode: 'Shift+N',
+} as const
+
 /** Display-friendly cheatsheet — a superset of PLAYER_HOTKEYS.
- *  Includes shortcuts registered in PlayerEditor (Mod+S, [, ]) that
- *  are not part of usePlayerKeyboard. */
+ *  Includes shortcuts registered in PlayerEditor (Mod+S, [, ]) and
+ *  EPISODE_HOTKEYS that are not part of usePlayerKeyboard. */
 export const PLAYER_SHORTCUT_CHEATSHEET = Object.freeze([
   // togglePlay uses { key } shape because useHotkey receives it as a KeyboardEvent.key value
   { labelKey: 'shortcuts.playPause', hotkeys: [PLAYER_HOTKEYS.togglePlay.key] },
@@ -54,6 +60,11 @@ export const PLAYER_SHORTCUT_CHEATSHEET = Object.freeze([
   { labelKey: 'shortcuts.saveAll', hotkeys: ['Mod+S'] },
   { labelKey: 'shortcuts.prevSegment', hotkeys: ['['] },
   { labelKey: 'shortcuts.nextSegment', hotkeys: [']'] },
+  {
+    labelKey: 'shortcuts.prevEpisode',
+    hotkeys: [EPISODE_HOTKEYS.previousEpisode],
+  },
+  { labelKey: 'shortcuts.nextEpisode', hotkeys: [EPISODE_HOTKEYS.nextEpisode] },
   {
     labelKey: 'shortcuts.stepFrameBackForward',
     hotkeys: [

--- a/src/lib/series-utils.ts
+++ b/src/lib/series-utils.ts
@@ -1,0 +1,10 @@
+import type { BaseItemDto } from '@/types/jellyfin'
+
+/**
+ * Whether a season is the series' Specials season (see CONTEXT.md).
+ * Jellyfin numbers Specials as season 0, but some metadata providers
+ * number them differently, so the name is checked as well.
+ */
+export const isSpecialSeason = (season: BaseItemDto): boolean =>
+  season.IndexNumber === 0 ||
+  (season.Name ?? '').toLowerCase().includes('special')

--- a/src/services/items/queries.ts
+++ b/src/services/items/queries.ts
@@ -1,5 +1,11 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import type { QueryClient } from '@tanstack/react-query'
 import { createStandardQueryOptions } from '@/hooks/queries/create-query-hook'
+import { resolveAdjacentEpisodes } from '@/lib/adjacent-episodes'
 import type { PagedItemsResult } from '@/services/items/api'
 import type {
   BaseItemDto,
@@ -109,6 +115,28 @@ export const seriesQueryOptions = {
       cacheDuration: 'LONG',
       operation: 'Fetch episodes',
     }),
+  /** Adjacent Episodes of `episode`, resolved through the cached seasons and episodes queries above. */
+  adjacentEpisodes: (episode: BaseItemDto, queryClient: QueryClient) =>
+    createStandardQueryOptions({
+      queryKey: seriesKeys.adjacentEpisodes(
+        episode.SeriesId ?? '',
+        episode.Id ?? '',
+      ),
+      queryFn: () =>
+        resolveAdjacentEpisodes(
+          {
+            fetchSeasons: (seriesId) =>
+              queryClient.fetchQuery(seriesQueryOptions.seasons(seriesId)),
+            fetchEpisodes: (seriesId, seasonId) =>
+              queryClient.fetchQuery(
+                seriesQueryOptions.episodes(seriesId, seasonId),
+              ),
+          },
+          episode,
+        ),
+      cacheDuration: 'LONG',
+      operation: 'Fetch adjacent episodes',
+    }),
 } as const
 
 export const albumQueryOptions = {
@@ -186,6 +214,18 @@ export const useSeasons = (seriesId: string, opts?: UseEntityOptions) => {
   return useQuery({
     ...seriesQueryOptions.seasons(seriesId),
     enabled: isEntityQueryEnabled(seriesId, validAuth, opts),
+  })
+}
+
+/** Previous and next episode in Series Order for the arrows and hotkeys in the header. */
+export const useAdjacentEpisodes = (episode: BaseItemDto) => {
+  const validAuth = useApiStore(selectValidAuth)
+  const queryClient = useQueryClient()
+
+  return useQuery({
+    ...seriesQueryOptions.adjacentEpisodes(episode, queryClient),
+    enabled:
+      validAuth && !!episode.SeriesId && !!episode.SeasonId && !!episode.Id,
   })
 }
 

--- a/src/services/items/query-keys.ts
+++ b/src/services/items/query-keys.ts
@@ -20,6 +20,8 @@ export const seriesKeys = {
   seasons: (seriesId: string) => createQueryKey('series', 'seasons', seriesId),
   episodes: (seriesId: string, seasonId: string) =>
     createQueryKey('series', 'episodes', seriesId, seasonId),
+  adjacentEpisodes: (seriesId: string, episodeId: string) =>
+    createQueryKey('series', 'adjacentEpisodes', seriesId, episodeId),
 } as const
 
 export const albumKeys = {


### PR DESCRIPTION
Editing segments across a whole series meant opening the episode dropdown and scrolling for every single episode. #234 asked for arrows instead.

The header now has a next arrow after the episode title, with Shift+N doing the same from the keyboard and Shift+P stepping back. Only next gets an arrow: a second left chevron beside the back button was too easy to mix up, a sweep runs forward anyway, and the dropdown covers the rare step back. They follow series order: season 1 episode 8 steps into season 2 episode 1, seasons with no playable episodes are skipped, and Specials come last, after the final regular season, in the same order as the season tabs on the series page. At the last episode the arrow stays visible but dimmed, and both shortcuts do nothing at their respective ends.

```diff
 <Header>
-  <EpisodeSwitcher>
+  <EpisodeNavigation>            useAdjacentEpisodes(), Shift+P / Shift+N
+    <EpisodeSwitcher>
+    <NextEpisodeArrow>
```

Neighbours are resolved in `resolveAdjacentEpisodes`, fed by the same cached seasons and per-season episode queries the dropdown already uses, so the two can't disagree. The Specials check that the series page and the switcher each defined slightly differently is now one shared `isSpecialSeason`.

Leaving with unsaved edits goes through the existing discard dialog, on click and on shortcut alike.

Closes #234

## Summary by Sourcery

Enable fast navigation between adjacent series episodes from the player header and keyboard.

New Features:
- Add header navigation to the previous and next episodes with Shift+P and Shift+N shortcuts.
- Resolve episode adjacency across seasons in series order, including skipped empty seasons and trailing Specials.

Bug Fixes:
- Keep episode navigation consistent with the series page's Specials classification and handle merged Specials correctly.

Enhancements:
- Share episode route navigation and preloading between the episode switcher and navigation controls.
- Keep the next control visible but disabled at the end of a series and route navigation through the existing player behavior.

Documentation:
- Document episode navigation terminology and Series Order behavior.

Tests:
- Add coverage for cross-season adjacency, empty seasons, Specials ordering, series boundaries, and header navigation interactions.

Chores:
- Add localized labels for episode navigation and keyboard shortcuts.