### PR TITLE
style(player): make the next-episode arrow look like a button

### DIFF
--- a/src/components/header/EpisodeNavigation.tsx
+++ b/src/components/header/EpisodeNavigation.tsx
@@ -43,11 +43,15 @@ function NextEpisodeArrow({
       }}
       onPointerEnter={intent}
       onFocus={intent}
-      className="rounded-lg text-muted-foreground hover:text-foreground disabled:opacity-30"
+      className={cn(
+        'size-11 rounded-full transition-colors duration-150',
+        'bg-secondary/80 text-secondary-foreground hover:bg-secondary',
+        'focus-visible:ring-2 focus-visible:ring-ring active:scale-95',
+      )}
       aria-label={targetLabel ? `${label}: ${targetLabel}` : label}
       title={`${targetLabel ?? label} (${NEXT_HOTKEY_DISPLAY})`}
     >
-      <ChevronRight className="size-6" aria-hidden />
+      <ChevronRight className="size-5" aria-hidden />
     </Button>
   )
 }
@@ -61,7 +65,8 @@ interface EpisodeNavigationProps {
  * Header control for the player page: the Episode Switcher with a next arrow
  * after it, plus Shift+N for next and Shift+P for previous. Only next gets an
  * arrow, so it cannot be confused with the back button; a sweep runs forward
- * and the dropdown covers the rare step back. The arrow stays visible but
+ * and the dropdown covers the rare step back. It is styled like the header's
+ * other round icon buttons so it reads as a control, and stays visible but
  * disabled at the last episode of the series.
  */
 export default function EpisodeNavigation({


### PR DESCRIPTION
The next-episode arrow from #236 was a bare muted chevron sitting right after the dropdown's chevron, and the two together read as decoration rather than a control. Now that it's the only arrow in the header there's nothing on the left to confuse it with, so it takes the same round secondary style as the back, home and settings buttons.

No behaviour change. At the series end it is still disabled, now dimmed to the shared button default instead of the one-off 30% the bare chevron used, so it matches every other disabled button.